### PR TITLE
chore(vue.config.js): optimized package size

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -28,4 +28,15 @@ module.exports = {
       }),
     ],
   },
+  chainWebpack: (config) => {
+    config.optimization.splitChunks({
+      chunks: 'all',
+      cacheGroups: {
+        monacoEditor: {
+          name: 'chunk-monaco-editor',
+          test: /[\\/]node_modules[\\/]monaco-editor[\\/]/,
+        },
+      },
+    })
+  },
 }


### PR DESCRIPTION
Split the monaco-editor library into separate code blocks

For resolve this... I don't understand why it has become like this. There have been no changes to the relevant code of Monaco since v1.2.1.

And I found that there was no such problem before this commit https://github.com/emqx/emqx-dashboard5/commit/37326c9d6b3480e8b62c9987985221c060f90020, and it triggered the problem in some magical way.

![image](https://user-images.githubusercontent.com/26165221/233833523-9e4ba2ae-ce87-4860-ae68-4440b31d88be.png)
