### PR TITLE
chore(package.json): remove `--mode`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "serve:cloud": "vue-cli-service serve --mode cloud",
     "serve:enterprise:cloud": "vue-cli-service serve --mode enterprise.cloud",
     "build": "vue-cli-service build",
-    "build:enterprise": "vue-cli-service build --mode enterprise",
+    "build:enterprise": "VUE_APP_VERSION=enterprise vue-cli-service build",
     "test:unit": "vue-cli-service test:unit",
     "lint": "vue-cli-service lint",
     "format": "prettier --write \"src/**/*.js\" \"src/**/*.ts\" \"src/**/*.tsx\" \"src/**/*.vue\" \"src/**/*.scss\"",
@@ -34,11 +34,13 @@
     "mqtt": "^4.2.8",
     "nprogress": "^0.2.0",
     "sortablejs": "^1.14.0",
+    "terser-webpack-plugin": "^1.4.5",
     "utf8": "^3.0.0",
     "vue": "^3.2.16",
     "vue-i18n": "^9.2.0-beta.19",
     "vue-router": "^4.0.0-0",
     "vuex": "^4.0.0-0",
+    "webpack-bundle-analyzer": "^4.8.0",
     "xss": "^1.0.14"
   },
   "devDependencies": {

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+/* eslint-disable @typescript-eslint/no-var-requires */
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin')
 
 const { HOST_URL } = process.env


### PR DESCRIPTION
When build the enterprise version package

https://cli.vuejs.org/guide/mode-and-env.html#modes

After setting the `--mode` to `enterprise`, because there is no option for `enterprise` in the `--mode` value, it was set to the default value of `development`, resulting in a large package size.

<img width="810" alt="image" src="https://user-images.githubusercontent.com/26165221/233939898-dc1b8fde-da44-4910-948d-39125c92f710.png">
