### PR TITLE
refactor(bridge): hide resource_opt configs by default

### DIFF
--- a/src/views/RuleEngine/Bridge/Components/BridgeConfig/BridgeInfluxdbConfig.vue
+++ b/src/views/RuleEngine/Bridge/Components/BridgeConfig/BridgeInfluxdbConfig.vue
@@ -161,14 +161,17 @@
           />
         </el-form-item>
       </el-col>
-      <el-col :span="24"><el-divider /></el-col>
-      <BridgeResourceOpt
-        v-model="formData.resource_opts"
-        with-batch-config
-        :readonly="readonly"
-        :colSpan="colSpan"
-      />
     </el-row>
+    <AdvancedSettingContainer>
+      <el-row :gutter="26">
+        <BridgeResourceOpt
+          v-model="formData.resource_opts"
+          with-batch-config
+          :readonly="readonly"
+          :colSpan="colSpan"
+        />
+      </el-row>
+    </AdvancedSettingContainer>
   </el-form>
 </template>
 
@@ -178,6 +181,7 @@ import {
   getLabelFromValueInOptionList,
   waitAMoment,
 } from '@/common/tools'
+import AdvancedSettingContainer from '@/components/AdvancedSettingContainer.vue'
 import CustomFormItem from '@/components/CustomFormItem.vue'
 import InfoTooltip from '@/components/InfoTooltip.vue'
 import InputSelect from '@/components/InputSelect.vue'

--- a/src/views/RuleEngine/Bridge/Components/BridgeConfig/BridgeKafkaConfig.vue
+++ b/src/views/RuleEngine/Bridge/Components/BridgeConfig/BridgeKafkaConfig.vue
@@ -277,50 +277,52 @@
           />
         </el-col>
       </template>
-
-      <el-col :span="24"><el-divider /></el-col>
-
-      <!-- socket opt -->
-      <el-col :span="colSpan">
-        <CustomFormItem prop="socket_opts.sndbuf" :readonly="readonly">
-          <template #label>
-            <span>{{ getText('socket_send_buffer.label') }}</span>
-            <InfoTooltip :content="getText('socket_send_buffer.desc')" />
-          </template>
-          <InputWithUnit v-model="formData.socket_opts.sndbuf" :units="usefulMemoryUnit" />
-        </CustomFormItem>
-      </el-col>
-      <el-col :span="colSpan">
-        <CustomFormItem prop="socket_opts.recbuf" :readonly="readonly">
-          <template #label>
-            <span>{{ getText('socket_receive_buffer.label') }}</span>
-            <InfoTooltip :content="getText('socket_receive_buffer.desc')" />
-          </template>
-          <InputWithUnit v-model="formData.socket_opts.recbuf" :units="usefulMemoryUnit" />
-        </CustomFormItem>
-      </el-col>
-      <el-col :span="colSpan">
-        <CustomFormItem prop="socket_opts.tcp_keepalive" :readonly="readonly">
-          <template #label>
-            <FormItemLabel
-              :label="getText('tcp_keepalive.label')"
-              :desc="getText('tcp_keepalive.desc')"
-              desc-marked
-            />
-          </template>
-          <el-input v-model="formData.socket_opts.tcp_keepalive" />
-        </CustomFormItem>
-      </el-col>
-      <el-col :span="colSpan">
-        <CustomFormItem
-          prop="resource_opts.health_check_interval"
-          :label="t('RuleEngine.healthCheckInterval')"
-          :readonly="readonly"
-        >
-          <TimeInputWithUnitSelect v-model="formData.resource_opts.health_check_interval" />
-        </CustomFormItem>
-      </el-col>
     </el-row>
+
+    <!-- socket opt -->
+    <AdvancedSettingContainer>
+      <el-row :gutter="26">
+        <el-col :span="colSpan">
+          <CustomFormItem prop="socket_opts.sndbuf" :readonly="readonly">
+            <template #label>
+              <span>{{ getText('socket_send_buffer.label') }}</span>
+              <InfoTooltip :content="getText('socket_send_buffer.desc')" />
+            </template>
+            <InputWithUnit v-model="formData.socket_opts.sndbuf" :units="usefulMemoryUnit" />
+          </CustomFormItem>
+        </el-col>
+        <el-col :span="colSpan">
+          <CustomFormItem prop="socket_opts.recbuf" :readonly="readonly">
+            <template #label>
+              <span>{{ getText('socket_receive_buffer.label') }}</span>
+              <InfoTooltip :content="getText('socket_receive_buffer.desc')" />
+            </template>
+            <InputWithUnit v-model="formData.socket_opts.recbuf" :units="usefulMemoryUnit" />
+          </CustomFormItem>
+        </el-col>
+        <el-col :span="colSpan">
+          <CustomFormItem prop="socket_opts.tcp_keepalive" :readonly="readonly">
+            <template #label>
+              <FormItemLabel
+                :label="getText('tcp_keepalive.label')"
+                :desc="getText('tcp_keepalive.desc')"
+                desc-marked
+              />
+            </template>
+            <el-input v-model="formData.socket_opts.tcp_keepalive" />
+          </CustomFormItem>
+        </el-col>
+        <el-col :span="colSpan">
+          <CustomFormItem
+            prop="resource_opts.health_check_interval"
+            :label="t('RuleEngine.healthCheckInterval')"
+            :readonly="readonly"
+          >
+            <TimeInputWithUnitSelect v-model="formData.resource_opts.health_check_interval" />
+          </CustomFormItem>
+        </el-col>
+      </el-row>
+    </AdvancedSettingContainer>
   </el-form>
 </template>
 
@@ -331,6 +333,7 @@ import {
   usefulMemoryUnit,
   waitAMoment,
 } from '@/common/tools'
+import AdvancedSettingContainer from '@/components/AdvancedSettingContainer.vue'
 import CustomFormItem from '@/components/CustomFormItem.vue'
 import FormItemLabel from '@/components/FormItemLabel.vue'
 import InfoTooltip from '@/components/InfoTooltip.vue'

--- a/src/views/RuleEngine/Bridge/Components/BridgeConfig/BridgePulsarConfig.vue
+++ b/src/views/RuleEngine/Bridge/Components/BridgeConfig/BridgePulsarConfig.vue
@@ -253,23 +253,27 @@
           <el-switch v-model="formData.buffer.memory_overload_protection" :disabled="readonly" />
         </el-form-item>
       </el-col>
-      <el-col :span="colSpan">
-        <CustomFormItem prop="resource_opts.start_timeout" :readonly="readonly">
-          <template #label>
-            <FormItemLabel v-bind="getResourceOptLabelProp('start_timeout')" />
-          </template>
-          <TimeInputWithUnitSelect v-model="formData.resource_opts.start_timeout" />
-        </CustomFormItem>
-      </el-col>
-      <el-col :span="colSpan">
-        <CustomFormItem prop="resource_opts.health_check_interval" :readonly="readonly">
-          <template #label>
-            <FormItemLabel v-bind="getResourceOptLabelProp('health_check_interval')" />
-          </template>
-          <TimeInputWithUnitSelect v-model="formData.resource_opts.health_check_interval" />
-        </CustomFormItem>
-      </el-col>
     </el-row>
+    <AdvancedSettingContainer>
+      <el-row :gutter="26">
+        <el-col :span="colSpan">
+          <CustomFormItem prop="resource_opts.start_timeout" :readonly="readonly">
+            <template #label>
+              <FormItemLabel v-bind="getResourceOptLabelProp('start_timeout')" />
+            </template>
+            <TimeInputWithUnitSelect v-model="formData.resource_opts.start_timeout" />
+          </CustomFormItem>
+        </el-col>
+        <el-col :span="colSpan">
+          <CustomFormItem prop="resource_opts.health_check_interval" :readonly="readonly">
+            <template #label>
+              <FormItemLabel v-bind="getResourceOptLabelProp('health_check_interval')" />
+            </template>
+            <TimeInputWithUnitSelect v-model="formData.resource_opts.health_check_interval" />
+          </CustomFormItem>
+        </el-col>
+      </el-row>
+    </AdvancedSettingContainer>
   </el-form>
 </template>
 
@@ -280,6 +284,7 @@ import {
   usefulMemoryUnit,
   waitAMoment,
 } from '@/common/tools'
+import AdvancedSettingContainer from '@/components/AdvancedSettingContainer.vue'
 import CustomFormItem from '@/components/CustomFormItem.vue'
 import FormItemLabel from '@/components/FormItemLabel.vue'
 import InputSelect from '@/components/InputSelect.vue'

--- a/src/views/RuleEngine/Bridge/Components/BridgeConfig/InfluxdbWriteSyntaxInput.vue
+++ b/src/views/RuleEngine/Bridge/Components/BridgeConfig/InfluxdbWriteSyntaxInput.vue
@@ -103,5 +103,8 @@ defineExpose({ validate, clearValidate })
   .type-select {
     margin-bottom: 16px;
   }
+  .el-card {
+    margin-bottom: 0;
+  }
 }
 </style>


### PR DESCRIPTION
in Kafka, Pulsar and InfluxDB