### PR TITLE
fix(message): error msg cannot be closed when error msg is too long

### DIFF
--- a/src/common/CustomMessage.ts
+++ b/src/common/CustomMessage.ts
@@ -23,7 +23,9 @@ const message: any = (options: MessageOptions) => {
   const { message, duration: dur, showClose: showC, type } = normalizeOptions(options)
   const duration = dur || (message && countDuration(message as string)) || undefined
   const showClose = showC || type === 'error'
-  return ElMessage({ ...options, duration, showClose })
+  const instance = ElMessage({ ...options, duration, showClose })
+  window.setTimeout(() => instance?.close?.(), duration ? duration + 2000 : 8000)
+  return instance
 }
 
 messageTypes.forEach((type) => {

--- a/src/style/normalize.scss
+++ b/src/style/normalize.scss
@@ -641,8 +641,11 @@
   .el-message__content {
     color: #343741;
     line-height: 1.5;
+    word-break: break-all;
   }
   .el-message__closeBtn {
+    transform: none;
+    top: 16px + math.div(14px * 0.5, 2);
     color: #343741;
     font-size: 14px;
   }


### PR DESCRIPTION
https://emqx.atlassian.net/browse/ED-566

Fixed from two aspects:
1. Call the close method 2 seconds after duration
2. Move the close button to the top right corner of the pop-up
