### PR TITLE
fix(session): the smallest unit of Session Expiry Interval should be second rather than milliseconds

### DIFF
--- a/src/views/Config/BasicConfig/Session.vue
+++ b/src/views/Config/BasicConfig/Session.vue
@@ -92,6 +92,10 @@ export default defineComponent({
           trigger: 'blur',
         }
       }
+      const expiryInterval = mqttComponent.properties.session_expiry_interval
+      if (expiryInterval) {
+        expiryInterval.componentProps = { enabledUnits: ['s', 'm', 'h'] }
+      }
       return { components, rules }
     }
 


### PR DESCRIPTION
https://emqx.atlassian.net/browse/ED-829