### PR TITLE
refactor(connector): handling connectors which can not view

### DIFF
--- a/src/hooks/Rule/connector/useMixedConnectorList.ts
+++ b/src/hooks/Rule/connector/useMixedConnectorList.ts
@@ -1,11 +1,10 @@
 import { getActions } from '@/api/action'
 import { getConnectors } from '@/api/connector'
 import { getBridgeList } from '@/api/ruleengine'
-import { SUPPORTED_CONNECTOR_TYPES } from '@/common/constants'
 import { getBridgeKey, omitArr } from '@/common/tools'
 import { BridgeType } from '@/types/enum'
 import { BridgeItem, Connector } from '@/types/rule'
-import { useOldNewType } from '../bridge/useBridgeTypeValue'
+import { isConnectorSupported, useOldNewType } from '../bridge/useBridgeTypeValue'
 
 export default (): {
   getMixedConnectorList: () => Promise<Array<Connector | BridgeItem>>
@@ -47,8 +46,8 @@ export default (): {
           const connectorIndex = connectorList.findIndex(({ id }) => id === associatedConnectorId)
           if (connectorIndex !== -1) {
             if (
-              SUPPORTED_CONNECTOR_TYPES.includes(oldType) ||
-              (newType && SUPPORTED_CONNECTOR_TYPES.includes(newType as BridgeType))
+              isConnectorSupported(oldType) ||
+              (newType && isConnectorSupported(newType as BridgeType))
             ) {
               bridgeIndexArrNeedRemoved.push(bridgeIndex)
             } else {
@@ -61,6 +60,11 @@ export default (): {
         connectorList,
         connectorIndexArrNeedRemoved,
       )
+      connectorListRemovedBridge.forEach((item) => {
+        if (!isConnectorSupported(item.type)) {
+          item.canNotView = true
+        }
+      })
       const bridgeListRemovedConnector: Array<BridgeItem> = omitArr(
         bridgeList,
         bridgeIndexArrNeedRemoved,

--- a/src/i18n/RuleEngine.js
+++ b/src/i18n/RuleEngine.js
@@ -802,6 +802,10 @@ export default {
     zh: '是否使用该动作创建规则',
     en: 'Would you like to create a rule using this connector?',
   },
+  canNotViewConnectorTip: {
+    zh: '暂不支持通过 Dashboard 管理此连接器',
+    en: 'This connector cannot be managed through the dashboard at the moment',
+  },
   console: {
     zh: '打印结果输出到控制台',
     en: 'Print the result to the Console',

--- a/src/views/RuleEngine/Connector/Connector.vue
+++ b/src/views/RuleEngine/Connector/Connector.vue
@@ -10,15 +10,29 @@
       <el-table :data="tableData" ref="TableCom" row-key="id" v-loading.lock="isLoading">
         <el-table-column :label="tl('name')" :min-width="120">
           <template #default="{ row }">
-            <router-link :to="getDetailPageRoute(row)" class="first-column-with-icon-type">
-              <img v-if="row.type" class="icon-type" :src="getBridgeIcon(row.type)" />
-              <div class="name-type-block">
-                <span class="name-data">
-                  {{ row.name }}
-                </span>
-                <span class="type-data">{{ getTypeStr(row.type) }}</span>
+            <el-tooltip
+              class="box-item"
+              effect="dark"
+              placement="top"
+              :disabled="!row.canNotView"
+              :content="tl('canNotViewConnectorTip')"
+            >
+              <div class="tooltip-content">
+                <router-link
+                  :to="row.canNotView ? '' : getDetailPageRoute(row)"
+                  class="first-column-with-icon-type link-detail"
+                  :class="{ 'is-disabled': row.canNotView }"
+                >
+                  <img v-if="row.type" class="icon-type" :src="getBridgeIcon(row.type)" />
+                  <div class="name-type-block">
+                    <span class="name-data">
+                      {{ row.name }}
+                    </span>
+                    <span class="type-data">{{ getTypeStr(row.type) }}</span>
+                  </div>
+                </router-link>
               </div>
-            </router-link>
+            </el-tooltip>
           </template>
         </el-table-column>
         <el-table-column :label="tl('connectionStatus')">
@@ -31,24 +45,40 @@
         </el-table-column> -->
         <el-table-column :label="$t('Base.operation')" :min-width="168">
           <template #default="{ row }">
-            <el-button
-              size="small"
-              v-if="isErrorStatus(row)"
-              :loading="reconnectingMap.get(row.id)"
-              @click="reconnect(row)"
+            <el-tooltip
+              class="box-item"
+              effect="dark"
+              placement="top-start"
+              :disabled="!row.canNotView"
+              :content="tl('canNotViewConnectorTip')"
             >
-              {{ $t('RuleEngine.reconnect') }}
-            </el-button>
-            <el-button size="small" @click="$router.push(getDetailPageRoute(row))">
-              {{ $t('Base.setting') }}
-            </el-button>
-            <!-- TODO:disable del -->
-            <!-- :disable-del="row.XXXXXX" -->
-            <TableItemDropDown
-              :row-data="row"
-              @copy="copyConnectorItem(row)"
-              @delete="handleDeleteConnector(row)"
-            />
+              <div class="tooltip-content">
+                <el-button
+                  size="small"
+                  v-if="isErrorStatus(row)"
+                  :disabled="row.canNotView"
+                  :loading="reconnectingMap.get(row.id)"
+                  @click="reconnect(row)"
+                >
+                  {{ $t('RuleEngine.reconnect') }}
+                </el-button>
+                <el-button
+                  size="small"
+                  :disabled="row.canNotView"
+                  @click="$router.push(getDetailPageRoute(row))"
+                >
+                  {{ $t('Base.setting') }}
+                </el-button>
+                <!-- TODO:disable del -->
+                <!-- :disable-del="row.XXXXXX" -->
+                <TableItemDropDown
+                  :row-data="row"
+                  :disabled="row.canNotView"
+                  @copy="copyConnectorItem(row)"
+                  @delete="handleDeleteConnector(row)"
+                />
+              </div>
+            </el-tooltip>
           </template>
         </el-table-column>
       </el-table>
@@ -188,3 +218,19 @@ const { getTypeStr } = useConnectorTypeValue()
 
 getList()
 </script>
+
+<style lang="scss">
+.connectors {
+  .tooltip-content {
+    width: -webkit-fit-content;
+    width: fit-content;
+  }
+  .link-detail {
+    &.is-disabled {
+      .name-data {
+        color: var(--color-text-primary);
+      }
+    }
+  }
+}
+</style>

--- a/src/views/RuleEngine/components/TableItemDropDown.vue
+++ b/src/views/RuleEngine/components/TableItemDropDown.vue
@@ -3,8 +3,9 @@
     @command="handleCommand(rowData, $event)"
     @visible-change="dropdownVisibleChanged"
     popper-class="table-dropdown-popper"
+    :disabled="disabled"
   >
-    <el-button class="table-dropdown-btn" size="small">
+    <el-button class="table-dropdown-btn" size="small" :disabled="disabled">
       <span>
         {{ $t('Base.more') }}
       </span>
@@ -54,6 +55,10 @@ defineProps({
     type: Object as PropType<PluginItem>,
   },
   isBridge: {
+    type: Boolean,
+    default: false,
+  },
+  disabled: {
     type: Boolean,
     default: false,
   },


### PR DESCRIPTION
Handle the situation where connectors created with v2 api cannot be viewed on the dashboard