### PR TITLE
refactor(bridge): add back func `resetRawBridgeInfoAfterComponentInit…

### DIFF
--- a/src/views/RuleEngine/Bridge/BridgeDetail.vue
+++ b/src/views/RuleEngine/Bridge/BridgeDetail.vue
@@ -278,6 +278,14 @@ const loadBridgeInfo = async () => {
   }
 }
 
+/**
+ * because each component will fill empty value to the bridgeInfo, so we need to
+ * reset the raw bridge info to prevent compare error
+ */
+const resetRawBridgeInfoAfterComponentInit = (bridgeInfo: BridgeItem) => {
+  rawBridgeInfo = _.cloneDeep(bridgeInfo)
+}
+
 const setBridgeInfoFromSchemaForm = () => {
   if (!BRIDGE_TYPES_NOT_USE_SCHEMA.includes(bridgeType.value)) {
     bridgeInfo.value = formCom.value.getFormRecord()


### PR DESCRIPTION
…` that was removed in CE