### PR TITLE
chore: add a default(true) value for enable when creating rule

### DIFF
--- a/src/hooks/Rule/rule/useRuleForm.ts
+++ b/src/hooks/Rule/rule/useRuleForm.ts
@@ -16,6 +16,7 @@ export default (): {
     sql: transSQLFormDataToSQL(DEFAULT_SELECT, [from]),
     actions: [],
     description: '',
+    enable: true
   })
 
   const getRuleDataForUpdate = ({

--- a/src/types/rule.d.ts
+++ b/src/types/rule.d.ts
@@ -38,11 +38,11 @@ export interface BasicRule {
   sql: string
   actions: Array<OutputItem>
   description: string
+  enable: boolean
 }
 
 export interface RuleForm extends BasicRule {
   created_at: string
-  enable: boolean
   from: FromData
 }
 

--- a/src/views/RuleEngine/components/RuleForm.vue
+++ b/src/views/RuleEngine/components/RuleForm.vue
@@ -182,6 +182,7 @@ const ruleValueDefault = {
   sql: transSQLFormDataToSQL(DEFAULT_SELECT, [DEFAULT_FROM]),
   actions: [],
   description: '',
+  enable: true,
 }
 
 let modelValueCache = ''


### PR DESCRIPTION
Every time a new rule is created, it is enabled by default, but there is no 'enable' field. So, let's add a default value. :)
> This change has no impact on users; other fields (description, sql) have default values when creating a new rule, but this one does not, which feels a bit Inconvenient and inconsistent. 