### PR TITLE
refactor(global): remove spaces before and after form values

### DIFF
--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -17,7 +17,7 @@ export function login(user: { password: string; username: string }): Promise<{
   token: string
   version: string
 }> {
-  return http.post('/login', user)
+  return http.post('/login', user, { keepSpaces: true })
 }
 
 export function logout(username: string) {

--- a/src/common/http.js
+++ b/src/common/http.js
@@ -9,6 +9,7 @@ import { stringifyObjSafely } from '@emqx/shared-ui-utils'
 import _ from 'lodash'
 import { API_BASE_URL, REQUEST_TIMEOUT_CODE } from '@/common/constants'
 import { BAD_TOKEN, TOKEN_TIME_OUT, NAME_PWD_ERROR } from '@/common/customErrorCode'
+import { trimValues } from '@/common/tools'
 import i18n from '@/i18n'
 
 NProgress.configure({ showSpinner: false, trickleSpeed: 200 })
@@ -30,6 +31,14 @@ axios.interceptors.request.use(
     config.signal = controller.signal
     config.controller = controller
     store.commit('ADD_ABORT_CONTROLLER', controller)
+
+    if (
+      !config.keepSpaces &&
+      ['post', 'put'].includes(config.method) &&
+      typeof config.data === 'object'
+    ) {
+      config.data = trimValues(config.data)
+    }
     return config
   },
   (error) => {

--- a/src/common/tools.ts
+++ b/src/common/tools.ts
@@ -748,3 +748,27 @@ export const accAdd = (arg1: number, arg2: number): number => {
   const adjustedArg2 = arg2 * multiplier
   return (adjustedArg1 + adjustedArg2) / multiplier
 }
+
+type TrimValuesParam = string | Record<string, any> | Array<TrimValuesParam>
+export const trimValues = (obj: TrimValuesParam, omitKeys?: Array<string>) => {
+  const ret = cloneDeep(obj)
+  const handle = (val: TrimValuesParam): TrimValuesParam => {
+    // If the value is from a textarea, don't handle spaces
+    if (typeof val === 'string' && !/\n/.test(val)) {
+      return val.trim()
+    }
+    if (Array.isArray(val)) {
+      return val.map((item) => handle(item))
+    }
+    if (isObject(val)) {
+      Object.entries(val).forEach(([key, value]) => {
+        if (omitKeys?.includes(key)) {
+          return
+        }
+        val[key] = handle(value)
+      })
+    }
+    return val
+  }
+  return handle(ret)
+}


### PR DESCRIPTION
I'm not sure this is the right way to handle it. Please take a look.

https://emqx.atlassian.net/browse/ED-1654

---

This pull request introduces several changes to improve the handling of whitespace in HTTP requests and to add a utility function for trimming values. The most important changes include modifying the login function to keep spaces, updating the HTTP request interceptor to trim values unless specified otherwise, and adding a new utility function to handle trimming.

### HTTP Request Handling Improvements:
* [`src/api/common.ts`](diffhunk://#diff-62eba76fe6cadaa56e99795f9b9fd052fa75b11f8d2a22bdcb0519eb43f723dcL20-R20): Modified the `login` function to include a `keepSpaces` option in the HTTP request.
* [`src/common/http.js`](diffhunk://#diff-8b3981483821f08209fd626431b1a580791498b11a161117bdd70bc8e7607a14R12): Added the `trimValues` import to handle trimming of values in HTTP requests.
* [`src/common/http.js`](diffhunk://#diff-8b3981483821f08209fd626431b1a580791498b11a161117bdd70bc8e7607a14R34-R41): Updated the `axios.interceptors.request.use` function to trim values in `POST` and `PUT` requests unless `keepSpaces` is specified.

### Utility Function Addition:
* [`src/common/tools.ts`](diffhunk://#diff-35169bc4bc0fb8270e4855086040dee50350355e7d87fd14f68422cdd36404d0R751-R774): Added a new `trimValues` function to recursively trim spaces from strings in an object, array, or string, with an option to omit specific keys.