### PR TITLE
ci: use GitHub App to create PRs in emqx/emqx

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -56,9 +56,17 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.AUTH_APP_ID }}
+          private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Create PR in emqx/emqx
         env:
-          GH_TOKEN: ${{ secrets.CI_GITHUB_TOKEN_EMQX_RW }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           EMQX_NAME: emqx
           VERSION: ${{ github.ref_name }}
         run: |
@@ -74,9 +82,17 @@ jobs:
     if: (github.ref == 'refs/heads/enterprise') || startsWith(github.ref, 'refs/tags/e')
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.AUTH_APP_ID }}
+          private-key: ${{ secrets.AUTH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Create PR in emqx/emqx
         env:
-          GH_TOKEN: ${{ secrets.CI_GITHUB_TOKEN_EMQX_RW }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           EMQX_NAME: emqx-enterprise
           VERSION: ${{ github.ref_name }}
         run: |


### PR DESCRIPTION
This is to get rid of PAT, and use ephemeral github app tokens instead.