### PR TITLE
refactor(i18n): update component translations to plural and more descriptive forms

### DIFF
--- a/src/i18n/components.js
+++ b/src/i18n/components.js
@@ -28,8 +28,8 @@ export default {
     en: 'Management',
   },
   diagnose: {
-    zh: '问题分析',
-    en: 'Diagnose',
+    zh: '诊断工具',
+    en: 'Diagnostics Tools',
   },
   acl: {
     zh: 'ACL',
@@ -189,7 +189,7 @@ export default {
   },
   extension: {
     zh: '扩展',
-    en: 'Extension',
+    en: 'Extensions',
   },
   'mqtt-system-topic': {
     zh: '系统主题',
@@ -237,7 +237,7 @@ export default {
   },
   'audit-log': {
     zh: '审计日志',
-    en: 'Audit Log',
+    en: 'Audit Logs',
   },
   system: {
     zh: '系统设置',
@@ -304,8 +304,8 @@ export default {
     en: 'Actions (Sink)',
   },
   schema: {
-    zh: 'Schema',
-    en: 'Schema',
+    zh: 'Schema Registry',
+    en: 'Schema Registry',
   },
   source: {
     zh: 'Sources',
@@ -369,7 +369,7 @@ export default {
   },
   'mqtt-session': {
     zh: '会话',
-    en: 'Session',
+    en: 'Sessions',
   },
   'mqtt-retainer': {
     zh: '保留消息',


### PR DESCRIPTION
https://emqx.atlassian.net/browse/ED-1748

This pull request includes various translation updates in the `src/i18n/components.js` file. The changes primarily focus on improving the accuracy and consistency of the English translations.

Translation updates:

* Updated `diagnose` to use "Diagnostics Tools" instead of "Diagnose"
* Changed `extension` to "Extensions" from "Extension"
* Modified `audit-log` to "Audit Logs" from "Audit Log"
* Updated `schema` to "Schema Registry" from "Schema"
* Changed `mqtt-session` to "Sessions" from "Session"