### PR TITLE
fix(topic metrics): load collection details by namespace

### DIFF
--- a/src/api/diagnose.ts
+++ b/src/api/diagnose.ts
@@ -13,6 +13,7 @@ import type {
   TopicMetricCollection,
   TopicMetricCollectionCreate,
 } from '@/types/typeAlias'
+import type { NsParams } from '@/types/rule'
 
 export const querySlowSubConfig = (): Promise<SlowSubConfig> => {
   return http.get('/slow_subscriptions/settings')
@@ -110,8 +111,11 @@ export function getTopicMetricCollections(): Promise<Array<TopicMetricCollection
   return http.get('/mqtt/topic_metrics2')
 }
 
-export function getTopicMetricCollection(name: string): Promise<TopicMetricCollection> {
-  return http.get('/mqtt/topic_metrics2/' + encodeURIComponent(name))
+export function getTopicMetricCollection(
+  name: string,
+  params?: NsParams,
+): Promise<TopicMetricCollection> {
+  return http.get('/mqtt/topic_metrics2/' + encodeURIComponent(name), { params })
 }
 
 export function createTopicMetricCollection(

--- a/src/views/Diagnose/TopicMetrics.vue
+++ b/src/views/Diagnose/TopicMetrics.vue
@@ -109,7 +109,7 @@
           {{ formatCount(getMetric(row, 'messages.dropped.count')) }}
         </template>
       </el-table-column>
-      <el-table-column :label="t('Base.operation')" width="220">
+      <el-table-column :label="t('Base.operation')" width="232">
         <template #default="{ row, $index }">
           <TableButton
             :disabled="!$hasPermission('get')"
@@ -220,6 +220,7 @@ const isMultiTenancyEnabled = useMultiTenancyEnabled()
 const isNamespaceUser = computed(() => store.getters.isNamespaceUser)
 const currentNamespace = computed(() => store.getters.userNamespace)
 const { isOpNsResourceDisabled } = useNsResource()
+const { getNsParams } = useNsParams()
 
 const tableRef = ref()
 const topicMetricsList = ref<Array<TopicMetricsRow>>([])
@@ -295,7 +296,7 @@ const loadTopicMetricsDetail = async (row: TopicMetricsRow, index: number, toggl
 
   row._loading = true
   try {
-    const data = await getTopicMetricCollection(row.name)
+    const data = await getTopicMetricCollection(row.name, getNsParams(row.namespace))
     topicMetricsList.value.splice(index, 1, {
       ...data,
       _expand: rowExpand,


### PR DESCRIPTION
- pass the namespace query parameter when loading collection details
- widen the actions column to preserve button spacing


fixes #3879
