### PR TITLE
fix(schema form): authenticate schema requests

### DIFF
--- a/src/common/tools.ts
+++ b/src/common/tools.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { cloneDeep, escape, get, isFunction, isObject, isUndefined, omit, round, set } from 'lodash'
 import moment from 'moment'
-import { API_BASE_URL, COPY_SUFFIX } from './constants'
+import { COPY_SUFFIX } from './constants'
 import { ListDataWithPagination } from '@/types/common'
 import { BridgeType } from '@/types/enum'
 
@@ -724,11 +724,6 @@ export const arraysAreEqual = <T>(arr1: T[], arr2: T[]): boolean => {
 
   return true
 }
-
-/**
- * add base url
- */
-export const getAPIPath = (url: string) => `${API_BASE_URL}${url}`
 
 export const omitArr = <T>(objectArray: Array<T>, indexArray: Array<number>): Array<T> => {
   return objectArray.filter((obj, index) => !indexArray.includes(index))

--- a/src/components/SchemaForm.tsx
+++ b/src/components/SchemaForm.tsx
@@ -1,5 +1,5 @@
 import { INTEGRATION_SCHEMA_TYPES, SESSION_FIELDS } from '@/common/constants'
-import { createRandomString, getAPIPath, waitAMoment } from '@/common/tools'
+import { createRandomString, waitAMoment } from '@/common/tools'
 import { isEmptyObj } from '@emqx/shared-ui-utils'
 import ArrayEditorTable from '@/components/ArrayEditorTable.vue'
 import CustomInputNumber from '@/components/CustomInputNumber.vue'
@@ -179,7 +179,7 @@ const SchemaForm = defineComponent({
   setup(props, ctx) {
     const { hasPermission } = usePerms()
     const configForm = ref<{ [key: string]: any }>({})
-    const schemaLoadPath = props.schemaFilePath || getAPIPath('/schemas/hotconf')
+    const schemaLoadPath = props.schemaFilePath || '/schemas/hotconf'
     const { components, rules, setTypeForProperty, resetObjForGetComponent } = useSchemaForm(
       schemaLoadPath,
       props.accordingTo,

--- a/src/hooks/Schema/useSchemaForm.ts
+++ b/src/hooks/Schema/useSchemaForm.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import http from '@/common/http'
 import { PropType } from '@/types/enum'
 import { Component, Properties, Property, Schema } from '@/types/schemaForm'
-import axios from 'axios'
 import { cloneDeep, get } from 'lodash'
 import type { Ref } from 'vue'
 import { ref } from 'vue'
@@ -45,9 +45,6 @@ export default function useSchemaForm(
 } {
   const { getters, commit } = useStore()
 
-  const schemaRequest = axios.create({
-    baseURL: '',
-  })
   let schema: any = {}
   const { rules, setToRules, countRules } = useSchemaFormRules()
   const { initRecordByComponents } = useSchemaRecord()
@@ -65,9 +62,9 @@ export default function useSchemaForm(
       if (data) {
         schema = data
       } else {
-        const res = await schemaRequest.get(configPath)
-        if (res.data) {
-          schema = removeUselessKey(res.data)
+        const schemaData = await http.get(configPath, { doNotTriggerProgress: true })
+        if (schemaData) {
+          schema = removeUselessKey(schemaData)
           commit('SET_SCHEMA_DATA', { key: configPath, data: cloneDeep(schema) })
         }
       }

--- a/src/hooks/Webhook/useWebhookForm.ts
+++ b/src/hooks/Webhook/useWebhookForm.ts
@@ -1,5 +1,4 @@
 import { WEBHOOK_SUFFIX } from '@/common/constants'
-import { getAPIPath } from '@/common/tools'
 import useRuleForm from '@/hooks/Rule/rule/useRuleForm'
 import { BridgeType } from '@/types/enum'
 import { ConnectorForm, HTTPBridge } from '@/types/rule'
@@ -22,13 +21,13 @@ export default (): {
   const { initRecordByComponents } = useSchemaRecord()
   const { components: httpConnectorComponents, schemaLoadPromise: connectorSchemaLoadPromise } =
     useSchemaForm(
-      getAPIPath(`/schemas/connectors`),
+      '/schemas/connectors',
       { ref: `#/components/schemas/bridge_http.post_connector` },
       false,
     )
   const { components: httpActionComponents, schemaLoadPromise: actionSchemaLoadPromise } =
     useSchemaForm(
-      getAPIPath(`/schemas/actions`),
+      '/schemas/actions',
       { ref: `#/components/schemas/${getActionTypeRefKey(BridgeType.Webhook)}` },
       false,
     )

--- a/src/views/RuleEngine/Bridge/Components/UsingSchemaBridgeConfig.vue
+++ b/src/views/RuleEngine/Bridge/Components/UsingSchemaBridgeConfig.vue
@@ -31,7 +31,6 @@
 </template>
 
 <script setup lang="ts">
-import { getAPIPath } from '@/common/tools'
 import SchemaForm from '@/components/SchemaForm'
 import { useActionSchema, useSourceSchema } from '@/hooks/Rule/bridge/useBridgeTypeValue'
 import useComponentsHandlers from '@/hooks/Rule/bridge/useComponentsHandlers'
@@ -80,7 +79,7 @@ const props = withDefaults(
 )
 const emit = defineEmits(['update:modelValue', 'init'])
 
-const schemaFilePath = computed(() => getAPIPath(`/schemas/actions`))
+const schemaFilePath = computed(() => '/schemas/actions')
 
 const schemaType = computed(() => {
   return props.isSource ? 'source' : 'action'

--- a/src/views/RuleEngine/Connector/components/ConnectorSchemaForm.vue
+++ b/src/views/RuleEngine/Connector/components/ConnectorSchemaForm.vue
@@ -5,7 +5,7 @@
       ref="formCom"
       type="connector"
       need-rules
-      :schema-file-path="getAPIPath(`/schemas/connectors`)"
+      schema-file-path="/schemas/connectors"
       :need-footer="false"
       :need-record="!edit && !copy"
       :form="connectorRecord"
@@ -28,7 +28,6 @@
 </template>
 
 <script setup lang="ts">
-import { getAPIPath } from '@/common/tools'
 import SchemaForm from '@/components/SchemaForm'
 import { useConnectorSchema } from '@/hooks/Rule/bridge/useBridgeTypeValue'
 import useSyncConfiguration from '@/hooks/Rule/bridge/useSyncConfiguration'


### PR DESCRIPTION
- load schemas through the shared HTTP client to include bearer authentication
- use relative schema API paths and remove the obsolete getAPIPath helper
- declare custom Axios request configuration options