### PR TITLE
fix(schema form): authenticate schema requests

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -177,7 +177,6 @@ declare global {
   const formatNumber: typeof import('./common/tools')['formatNumber']
   const formatSQL: typeof import('./common/tools')['formatSQL']
   const get: typeof import('lodash')['get']
-  const getAPIPath: typeof import('./common/tools')['getAPIPath']
   const getAllListData: typeof import('./common/tools')['getAllListData']
   const getBridgeKey: typeof import('./common/tools')['getBridgeKey']
   const getCurrentInstance: typeof import('vue')['getCurrentInstance']
@@ -754,7 +753,6 @@ declare module 'vue' {
     readonly formatNumber: UnwrapRef<typeof import('./common/tools')['formatNumber']>
     readonly formatSQL: UnwrapRef<typeof import('./common/tools')['formatSQL']>
     readonly get: UnwrapRef<typeof import('lodash')['get']>
-    readonly getAPIPath: UnwrapRef<typeof import('./common/tools')['getAPIPath']>
     readonly getAllListData: UnwrapRef<typeof import('./common/tools')['getAllListData']>
     readonly getBridgeKey: UnwrapRef<typeof import('./common/tools')['getBridgeKey']>
     readonly getCurrentInstance: UnwrapRef<typeof import('vue')['getCurrentInstance']>

--- a/src/common/http.ts
+++ b/src/common/http.ts
@@ -15,6 +15,16 @@ import axios from 'axios'
 import NProgress from 'nprogress'
 import 'nprogress/nprogress.css'
 
+declare module 'axios' {
+  export interface AxiosRequestConfig {
+    doNotTriggerProgress?: boolean
+    errorsHandleCustom?: number[]
+    handleTimeoutSelf?: boolean
+    controller?: AbortController
+    keepSpaces?: boolean
+  }
+}
+
 type CustomRequestConfig = InternalAxiosRequestConfig & {
   doNotTriggerProgress?: boolean
   errorsHandleCustom?: number[]

--- a/src/common/tools.ts
+++ b/src/common/tools.ts
@@ -751,11 +751,6 @@ export const arraysAreEqual = <T>(arr1: T[], arr2: T[]): boolean => {
   return true
 }
 
-/**
- * add base url
- */
-export const getAPIPath = (url: string) => `${API_BASE_URL}${url}`
-
 export const omitArr = <T>(objectArray: Array<T>, indexArray: Array<number>): Array<T> => {
   return objectArray.filter((obj, index) => !indexArray.includes(index))
 }

--- a/src/components/SchemaForm.tsx
+++ b/src/components/SchemaForm.tsx
@@ -1,5 +1,5 @@
 import { INTEGRATION_SCHEMA_TYPES, SESSION_FIELDS } from '@/common/constants'
-import { createRandomString, getAPIPath, waitAMoment } from '@/common/tools'
+import { createRandomString, waitAMoment } from '@/common/tools'
 import { isEmptyObj } from '@emqx/shared-ui-utils'
 import ArrayEditorTable from '@/components/ArrayEditorTable.vue'
 import CustomInputNumber from '@/components/CustomInputNumber.vue'
@@ -173,7 +173,7 @@ const SchemaForm = defineComponent({
   setup(props, ctx) {
     const { hasPermission } = usePerms()
     const configForm = ref<{ [key: string]: any }>({})
-    const schemaLoadPath = props.schemaFilePath || getAPIPath('/schemas/hotconf')
+    const schemaLoadPath = props.schemaFilePath || '/schemas/hotconf'
     const { components, rules, setTypeForProperty, resetObjForGetComponent } = useSchemaForm(
       schemaLoadPath,
       props.accordingTo,

--- a/src/hooks/Schema/useSchemaForm.ts
+++ b/src/hooks/Schema/useSchemaForm.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import http from '@/common/http'
 import { PropType } from '@/types/enum'
 import { Component, Properties, Property, Schema } from '@/types/schemaForm'
-import axios from 'axios'
 
 const CONNECTOR_CONF_KEYS = 'connector'
 
@@ -39,9 +39,6 @@ export default function useSchemaForm(
 } {
   const { getters, commit } = useStore()
 
-  const schemaRequest = axios.create({
-    baseURL: '',
-  })
   let schema: any = {}
   const { rules, setToRules, countRules } = useSchemaFormRules()
   const { initRecordByComponents } = useSchemaRecord()
@@ -59,9 +56,9 @@ export default function useSchemaForm(
       if (data) {
         schema = data
       } else {
-        const res = await schemaRequest.get(configPath)
-        if (res.data) {
-          schema = removeUselessKey(res.data)
+        const schemaData = await http.get(configPath, { doNotTriggerProgress: true })
+        if (schemaData) {
+          schema = removeUselessKey(schemaData)
           commit('SET_SCHEMA_DATA', { key: configPath, data: cloneDeep(schema) })
         }
       }

--- a/src/hooks/Webhook/useWebhookForm.ts
+++ b/src/hooks/Webhook/useWebhookForm.ts
@@ -15,13 +15,13 @@ export default (): {
   const { initRecordByComponents } = useSchemaRecord()
   const { components: httpConnectorComponents, schemaLoadPromise: connectorSchemaLoadPromise } =
     useSchemaForm(
-      getAPIPath(`/schemas/connectors`),
+      '/schemas/connectors',
       { ref: `#/components/schemas/bridge_http.post_connector` },
       false,
     )
   const { components: httpActionComponents, schemaLoadPromise: actionSchemaLoadPromise } =
     useSchemaForm(
-      getAPIPath(`/schemas/actions`),
+      '/schemas/actions',
       { ref: `#/components/schemas/${getActionTypeRefKey(BridgeType.Webhook)}` },
       false,
     )

--- a/src/views/RuleEngine/Bridge/Components/BridgeConfig/BridgeInfluxdbConfig.vue
+++ b/src/views/RuleEngine/Bridge/Components/BridgeConfig/BridgeInfluxdbConfig.vue
@@ -128,7 +128,7 @@ const getLabel = (key: string) => t(`BridgeSchema.common.${key}.label`)
 const getDesc = (key: string) =>
   t(`BridgeSchema.${props.modelValue?.type ?? 'influxdb'}.${key}.desc`)
 
-const { components } = useSchemaForm(getAPIPath(`/schemas/actions`), {
+const { components } = useSchemaForm('/schemas/actions', {
   ref: '#/components/schemas/bridge_influxdb.post_bridge_v2',
 })
 const { getPropItem } = useGetInfoFromComponents(components)

--- a/src/views/RuleEngine/Bridge/Components/UsingSchemaBridgeConfig.vue
+++ b/src/views/RuleEngine/Bridge/Components/UsingSchemaBridgeConfig.vue
@@ -71,7 +71,7 @@ const props = withDefaults(
 )
 const emit = defineEmits(['update:modelValue', 'init'])
 
-const schemaFilePath = computed(() => getAPIPath(`/schemas/actions`))
+const schemaFilePath = computed(() => '/schemas/actions')
 
 const schemaType = computed(() => {
   return props.isSource ? 'source' : 'action'

--- a/src/views/RuleEngine/Connector/components/ConnectorSchemaForm.vue
+++ b/src/views/RuleEngine/Connector/components/ConnectorSchemaForm.vue
@@ -5,7 +5,7 @@
       ref="formCom"
       type="connector"
       need-rules
-      :schema-file-path="getAPIPath(`/schemas/connectors`)"
+      schema-file-path="/schemas/connectors"
       :need-footer="false"
       :need-record="needRecord"
       :form="connectorRecord"


### PR DESCRIPTION
- load schemas through the shared HTTP client to include bearer authentication
- use relative schema API paths and remove the obsolete getAPIPath helper
- declare custom Axios request configuration options