### PR TITLE
feat(config): support denied namespace configuration

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -31,6 +31,7 @@ declare global {
   const CONNECTOR_TYPES_WITH_TWO_DIRECTIONS: typeof import('./common/constants')['CONNECTOR_TYPES_WITH_TWO_DIRECTIONS']
   const COPY_SUFFIX: typeof import('./common/constants')['COPY_SUFFIX']
   const CertBundleType: typeof import('./hooks/useCertBundle')['CertBundleType']
+  const DASHBOARD_USERNAME_REG: typeof import('./common/constants')['DASHBOARD_USERNAME_REG']
   const DEFAULT_ACTION_AND_SOURCE_TABLE_COLUMNS: typeof import('./common/constants')['DEFAULT_ACTION_AND_SOURCE_TABLE_COLUMNS']
   const DEFAULT_CLIENT_TABLE_COLUMNS: typeof import('./common/constants')['DEFAULT_CLIENT_TABLE_COLUMNS']
   const DEFAULT_FROM: typeof import('./common/constants')['DEFAULT_FROM']
@@ -642,6 +643,7 @@ declare module 'vue' {
     readonly CONNECTOR_TYPES_WITH_TWO_DIRECTIONS: UnwrapRef<typeof import('./common/constants')['CONNECTOR_TYPES_WITH_TWO_DIRECTIONS']>
     readonly COPY_SUFFIX: UnwrapRef<typeof import('./common/constants')['COPY_SUFFIX']>
     readonly CertBundleType: UnwrapRef<typeof import('./hooks/useCertBundle')['CertBundleType']>
+    readonly DASHBOARD_USERNAME_REG: UnwrapRef<typeof import('./common/constants')['DASHBOARD_USERNAME_REG']>
     readonly DEFAULT_ACTION_AND_SOURCE_TABLE_COLUMNS: UnwrapRef<typeof import('./common/constants')['DEFAULT_ACTION_AND_SOURCE_TABLE_COLUMNS']>
     readonly DEFAULT_CLIENT_TABLE_COLUMNS: UnwrapRef<typeof import('./common/constants')['DEFAULT_CLIENT_TABLE_COLUMNS']>
     readonly DEFAULT_FROM: UnwrapRef<typeof import('./common/constants')['DEFAULT_FROM']>

--- a/src/i18n/BasicConfig.ts
+++ b/src/i18n/BasicConfig.ts
@@ -366,6 +366,16 @@ These clients must be manually kicked out if one wants them to abide to the new 
     zh: '如果启用，属于非显式创建的命名空间的客户端将被拒绝连接。无法解析其命名空间的客户端也将被拒绝连接。',
     en: "If enabled, clients that belong to a non-explicitly created namespace will be denied connection. Clients that can't have their namespace resolved will also be denied connection.",
   },
+  deniedNamespaceNames: {
+    zh: '禁止使用的命名空间名称',
+    en: 'Denied Namespace Names',
+  },
+  deniedNamespaceNamesDesc: {
+    zh: `不能用作命名空间标识符的名称。该限制适用于 Dashboard 用户角色、API 密钥、多租户管理 API 和客户端 \`client_attrs.tns\`。<br />
+默认值为 \`global\`、\`undefined\`、\`null\` 和 \`none\`。清空列表可禁用此限制。`,
+    en: `Namespace names that cannot be used by Dashboard user roles, API keys, the multi-tenancy management API, or client \`client_attrs.tns\`.<br />
+The defaults are \`global\`, \`undefined\`, \`null\`, and \`none\`. Clear the list to disable this restriction.`,
+  },
   enableMessageQueue: {
     zh: '启用队列',
     en: 'Enable Queues',

--- a/src/views/Config/BasicConfig/components/NamespaceConfigDrawer.vue
+++ b/src/views/Config/BasicConfig/components/NamespaceConfigDrawer.vue
@@ -34,6 +34,17 @@
             :items="[{ type: 'number' }, { symbols: [INFINITY_VALUE], type: 'enum' }]"
           />
         </el-form-item>
+        <el-form-item prop="deny_namespaces">
+          <template #label>
+            <FormItemLabel
+              :max-height="360"
+              :label="tl('deniedNamespaceNames')"
+              :desc="tl('deniedNamespaceNamesDesc')"
+              desc-marked
+            />
+          </template>
+          <ArrayEditor v-model="record.deny_namespaces" />
+        </el-form-item>
       </el-form>
       <el-divider>
         <span class="text-nowrap">{{ t('BasicConfig.namespaceRelatedConfig') }}</span>
@@ -144,6 +155,7 @@ import { FormInstance } from 'element-plus'
 
 const CLIENT_ID_OVERRIDE_DISABLED = 'disabled'
 const DEFAULT_OVERRIDE_EXP = `concat([client_attrs.tns, '-', clientid])`
+const DEFAULT_DENY_NAMESPACES = ['global', 'undefined', 'null', 'none']
 
 const MULTI_TENANCY_KEY = 'multi_tenancy'
 enum NamespaceSourceTiming {
@@ -153,10 +165,18 @@ enum NamespaceSourceTiming {
 
 const { t } = useI18n()
 
-const createDefaultRecord = () => ({
+type MultiTenancyConfig = {
+  default_max_sessions: number | string
+  allow_only_managed_namespaces: boolean
+  post_auth_tns_expression: string
+  deny_namespaces: string[]
+}
+
+const createDefaultRecord = (): MultiTenancyConfig => ({
   default_max_sessions: 1000,
   allow_only_managed_namespaces: false,
   post_auth_tns_expression: '',
+  deny_namespaces: [...DEFAULT_DENY_NAMESPACES],
 })
 const record = ref(createDefaultRecord())
 const namespaceSourceTiming = ref<NamespaceSourceTiming>(NamespaceSourceTiming.BeforeAuth)
@@ -227,7 +247,8 @@ const updateNamespaceConfig = async () => {
     const data = `multi_tenancy {
     allow_only_managed_namespaces = ${record.value.allow_only_managed_namespaces}, 
     default_max_sessions = ${record.value.default_max_sessions},
-    post_auth_tns_expression = ${JSON.stringify(record.value.post_auth_tns_expression ?? '')}
+    post_auth_tns_expression = ${JSON.stringify(record.value.post_auth_tns_expression ?? '')},
+    deny_namespaces = ${JSON.stringify(record.value.deny_namespaces ?? [])}
 }`
     await putConfigs(data)
     return Promise.resolve()


### PR DESCRIPTION
- add an editor for multi_tenancy.deny_namespaces
- persist custom and empty deny lists through the HOCON config API
- document the setting in English and Chinese

fixes #3904 