### PR TITLE
fix(namespace): distinguish global scope from global namespace

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -60,6 +60,7 @@ declare global {
   const GATEWAY_ENABLED_MECHANISM_MAP: typeof import('./common/constants')['GATEWAY_ENABLED_MECHANISM_MAP']
   const GEMINI_DEFAULT_BASE_URL: typeof import('./common/constants')['GEMINI_DEFAULT_BASE_URL']
   const GLOBAL_NAMESPACE: typeof import('./common/constants')['GLOBAL_NAMESPACE']
+  const GLOBAL_NAMESPACE_VALUE: typeof import('./common/constants')['GLOBAL_NAMESPACE_VALUE']
   const HTTP_POST_DEFAULT_HEADERS: typeof import('./common/constants')['HTTP_POST_DEFAULT_HEADERS']
   const INFINITY_VALUE: typeof import('./common/constants')['INFINITY_VALUE']
   const INGRESS_BRIDGE_TYPES: typeof import('./common/constants')['INGRESS_BRIDGE_TYPES']
@@ -611,6 +612,9 @@ declare global {
   // @ts-ignore
   export type { DataFilterItem } from './hooks/usePaging'
   import('./hooks/usePaging')
+  // @ts-ignore
+  export type { NamespaceSelection } from './common/constants'
+  import('./common/constants')
 }
 
 // for vue template auto import
@@ -672,6 +676,7 @@ declare module 'vue' {
     readonly GATEWAY_ENABLED_MECHANISM_MAP: UnwrapRef<typeof import('./common/constants')['GATEWAY_ENABLED_MECHANISM_MAP']>
     readonly GEMINI_DEFAULT_BASE_URL: UnwrapRef<typeof import('./common/constants')['GEMINI_DEFAULT_BASE_URL']>
     readonly GLOBAL_NAMESPACE: UnwrapRef<typeof import('./common/constants')['GLOBAL_NAMESPACE']>
+    readonly GLOBAL_NAMESPACE_VALUE: UnwrapRef<typeof import('./common/constants')['GLOBAL_NAMESPACE_VALUE']>
     readonly HTTP_POST_DEFAULT_HEADERS: UnwrapRef<typeof import('./common/constants')['HTTP_POST_DEFAULT_HEADERS']>
     readonly INFINITY_VALUE: UnwrapRef<typeof import('./common/constants')['INFINITY_VALUE']>
     readonly INGRESS_BRIDGE_TYPES: UnwrapRef<typeof import('./common/constants')['INGRESS_BRIDGE_TYPES']>

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -495,6 +495,14 @@ export const GEMINI_DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.co
 
 export const GLOBAL_NAMESPACE = 'global'
 
+/**
+ * Frontend-only value used by namespace selectors to represent global scope.
+ * Managed namespace names are strings, so this cannot collide with names such as
+ * `global` or `0`.
+ */
+export const GLOBAL_NAMESPACE_VALUE = 0 as const
+export type NamespaceSelection = string | typeof GLOBAL_NAMESPACE_VALUE
+
 export const EMQX_AUTH_COOKIE_NAME = 'emqx_auth'
 
 export const QUERY_TAB = 'tab'

--- a/src/components/Namespace/NamespaceSelect.vue
+++ b/src/components/Namespace/NamespaceSelect.vue
@@ -20,15 +20,16 @@
 </template>
 
 <script setup lang="ts">
+import { GLOBAL_NAMESPACE_VALUE, type NamespaceSelection } from '@/common/constants'
 import useMultiTenancyEnabled from '@/hooks/Config/useMultiTenancyEnabled'
 import { OptionList } from '@/types/common'
 
 const props = withDefaults(
   defineProps<{
-    modelValue?: string
+    modelValue?: NamespaceSelection
     global?: {
       enable?: boolean
-      value?: string
+      value?: NamespaceSelection
     }
     placeholder?: string
     clearable?: boolean
@@ -41,18 +42,18 @@ const props = withDefaults(
   },
 )
 const emit = defineEmits<{
-  (e: 'update:modelValue', val: string | undefined): void
-  (e: 'change', val: string | undefined): void
+  (e: 'update:modelValue', val: NamespaceSelection | undefined): void
+  (e: 'change', val: NamespaceSelection | undefined): void
   (e: 'loaded'): void
 }>()
 
-const toModelValue = (val: string | undefined) =>
-  val === GLOBAL_NAMESPACE ? props.global.value : val
+const toModelValue = (val: NamespaceSelection | undefined) =>
+  val === GLOBAL_NAMESPACE_VALUE ? props.global.value : val
 
 const namespace = computed({
   get() {
     if (props.global.enable && props.modelValue === props.global.value) {
-      return GLOBAL_NAMESPACE
+      return GLOBAL_NAMESPACE_VALUE
     }
     return props.modelValue
   },
@@ -63,7 +64,7 @@ const namespace = computed({
 
 const { t } = useI18n()
 const loading = ref(false)
-const namespaceOptions = ref<OptionList<string>>([])
+const namespaceOptions = ref<OptionList<NamespaceSelection>>([])
 const isMultiTenancyEnabled = useMultiTenancyEnabled()
 const { globalNamespaceOption, getNamespaceOptions: requestNamespaceOptions } =
   useManagedNamespaceOptions()
@@ -88,7 +89,7 @@ const loadNamespaceOptions = async () => {
   }
 }
 
-const handleChange = (val: string | undefined) => {
+const handleChange = (val: NamespaceSelection | undefined) => {
   emit('change', toModelValue(val))
 }
 

--- a/src/components/TLSConfig/ManagedCertConfig.vue
+++ b/src/components/TLSConfig/ManagedCertConfig.vue
@@ -58,6 +58,7 @@
 </template>
 
 <script setup lang="ts">
+import { GLOBAL_NAMESPACE_VALUE, type NamespaceSelection } from '@/common/constants'
 import CertBundleInfo from '@/components/TLSConfig/CertBundleInfo.vue'
 import useMultiTenancyEnabled from '@/hooks/Config/useMultiTenancyEnabled'
 import { OptionList } from '@/types/common'
@@ -110,12 +111,12 @@ const record = computed<ManagedCerts>({
 const namespace = computed({
   get() {
     if (!record.value.namespace) {
-      return GLOBAL_NAMESPACE
+      return GLOBAL_NAMESPACE_VALUE
     }
     return record.value.namespace
   },
   set(val) {
-    if (val === GLOBAL_NAMESPACE) {
+    if (val === GLOBAL_NAMESPACE_VALUE) {
       delete record.value.namespace
     } else {
       record.value.namespace = val
@@ -123,7 +124,7 @@ const namespace = computed({
   },
 })
 const selectedNamespace = computed(() => {
-  if (!isMultiTenancyEnabled.value || namespace.value === GLOBAL_NAMESPACE) {
+  if (!isMultiTenancyEnabled.value || namespace.value === GLOBAL_NAMESPACE_VALUE) {
     return undefined
   }
   return namespace.value
@@ -131,7 +132,7 @@ const selectedNamespace = computed(() => {
 
 const { globalNamespaceOption, getNamespaceOptions: requestNamespaceOptions } =
   useManagedNamespaceOptions()
-const namespaceOptions = ref<OptionList<string>>([globalNamespaceOption])
+const namespaceOptions = ref<OptionList<NamespaceSelection>>([globalNamespaceOption])
 
 const getNamespaceOptions = async () => {
   namespaceOptions.value = [globalNamespaceOption]
@@ -153,8 +154,8 @@ const setOptionsDisabled = () => {
     props.allManagedCerts.forEach((cert, index) => {
       // Exclude current index and only add bundle names in the same namespace
       if (index !== props.currentIndex && cert.bundle_name) {
-        const certNamespace = cert.namespace || GLOBAL_NAMESPACE
-        const currentNamespace = namespace.value || GLOBAL_NAMESPACE
+        const certNamespace = cert.namespace || GLOBAL_NAMESPACE_VALUE
+        const currentNamespace = namespace.value || GLOBAL_NAMESPACE_VALUE
         if (certNamespace === currentNamespace) {
           usedBundleNames.add(cert.bundle_name)
         }
@@ -202,7 +203,7 @@ const createNewCertBundle = () => {
   isCreateDrawerVisible.value = true
 }
 const handleSubmit = ({ namespace: ns, bundle_name: name }: ManagedCerts) => {
-  const newNs = ns ?? GLOBAL_NAMESPACE
+  const newNs = ns ?? GLOBAL_NAMESPACE_VALUE
   if (newNs !== namespace.value) {
     namespace.value = newNs
   }

--- a/src/hooks/Config/useNamespace.ts
+++ b/src/hooks/Config/useNamespace.ts
@@ -107,7 +107,7 @@ export const useManagedNamespaceOptions = () => {
   const currentUserNamespace = computed(() => store.getters.userNamespace)
   const globalNamespaceOption = {
     label: t('BasicConfig.global'),
-    value: 'global',
+    value: GLOBAL_NAMESPACE_VALUE,
   }
   const getNamespaceOptions = async () => {
     if (!isMultiTenancyEnabled.value) {

--- a/src/hooks/Config/useNamespaceUser.ts
+++ b/src/hooks/Config/useNamespaceUser.ts
@@ -30,11 +30,7 @@ const useNamespaceUser = () => {
   const processAPIKeyRecordForUpdating = <T extends { namespace?: string; role: string }>(
     data: T,
   ): T => {
-    const ret = { ...data }
-    if (ret.namespace === GLOBAL_NAMESPACE) {
-      Reflect.deleteProperty(ret, 'namespace')
-    }
-    return processUserRecordForSubmit(ret)
+    return processUserRecordForSubmit({ ...data })
   }
 
   return {

--- a/src/hooks/Flow/useFlowView.ts
+++ b/src/hooks/Flow/useFlowView.ts
@@ -8,11 +8,12 @@ import useActionList from '../Rule/action/useActionList'
 import useSourceList from '../Rule/action/useSourceList'
 import useFlowNode, { FlowData, NodeType, ProcessingType } from './useFlowNode'
 import { ConnectionStatus } from '@/types/enum'
+import type { NamespaceSelection } from '@/common/constants'
 
 export default (): {
   isLoading: Ref<boolean>
   flowData: Ref<FlowData>
-  getFlowData: (ns: string) => Promise<void>
+  getFlowData: (ns: NamespaceSelection | undefined) => Promise<void>
 } => {
   let ruleList: Array<RuleItem> = []
   let bridgeData: Map<string, BridgeItem> = new Map()
@@ -36,7 +37,7 @@ export default (): {
   const flowData: Ref<FlowData> = ref([])
 
   const { getListNamespaceParams } = useListNsParams()
-  const getRuleData = async (namespace: string) => {
+  const getRuleData = async (namespace: NamespaceSelection | undefined) => {
     try {
       ruleList = await getAllListData((params) => {
         return getRules({ ...params, ...getListNamespaceParams(namespace) })
@@ -50,7 +51,7 @@ export default (): {
   const { getActionList } = useActionList()
   const { getSourceList } = useSourceList()
   const { getActionDetail, handleActionDataAfterLoaded } = useHandleActionItem()
-  const getBridgeData = async (namespace: string) => {
+  const getBridgeData = async (namespace: NamespaceSelection | undefined) => {
     try {
       const nsParams = getListNamespaceParams(namespace)
       const sourceList = await getSourceList(nsParams)
@@ -377,7 +378,7 @@ export default (): {
     }
   }
 
-  const getData = async (namespace: string) => {
+  const getData = async (namespace: NamespaceSelection | undefined) => {
     return await Promise.all([
       getRuleData(namespace),
       getBridgeData(namespace),
@@ -387,7 +388,7 @@ export default (): {
   }
 
   const { getEventList } = useRuleEvents()
-  const getFlowData = async (namespace: string) => {
+  const getFlowData = async (namespace: NamespaceSelection | undefined) => {
     try {
       isLoading.value = true
       await getData(namespace)

--- a/src/hooks/Rule/useNsParams.ts
+++ b/src/hooks/Rule/useNsParams.ts
@@ -1,6 +1,8 @@
+import { GLOBAL_NAMESPACE_VALUE, type NamespaceSelection } from '@/common/constants'
+
 export const useListNsParams = () => {
-  const getListNamespaceParams = (selectedNamespace: string | undefined) => {
-    if (selectedNamespace === GLOBAL_NAMESPACE) {
+  const getListNamespaceParams = (selectedNamespace: NamespaceSelection | undefined) => {
+    if (selectedNamespace === GLOBAL_NAMESPACE_VALUE) {
       return { only_global: true }
     } else if (selectedNamespace) {
       return { ns: selectedNamespace }

--- a/src/hooks/Rule/useNsResource.ts
+++ b/src/hooks/Rule/useNsResource.ts
@@ -4,7 +4,7 @@ const useNsResource = () => {
   const isOpNsResourceDisabled = ({
     namespace = undefined,
   }: { namespace?: string | null } & unknown = {}): boolean => {
-    return !!(!isNamespaceUser.value && namespace && namespace !== GLOBAL_NAMESPACE)
+    return !!(!isNamespaceUser.value && namespace)
   }
   return {
     isOpNsResourceDisabled,

--- a/src/hooks/Webhook/useWebhookList.ts
+++ b/src/hooks/Webhook/useWebhookList.ts
@@ -3,15 +3,16 @@ import { getConnectors as queryConnectors } from '@/api/connector'
 import { getRules as queryRules } from '@/api/ruleengine'
 import { BridgeItem, Connector, HTTPBridge, RuleItem } from '@/types/rule'
 import { WebhookItem } from '@/types/webhook'
+import type { NamespaceSelection } from '@/common/constants'
 
 export default (): {
-  namespaceFilter: Ref<string | undefined, string | undefined>
+  namespaceFilter: Ref<NamespaceSelection | undefined, NamespaceSelection | undefined>
   webhookList: Ref<WebhookItem[]>
   isLoading: Ref<boolean>
   isEmpty: Ref<boolean>
   getWebhookList: () => Promise<void>
 } => {
-  const namespaceFilter = ref<string | undefined>(undefined)
+  const namespaceFilter = ref<NamespaceSelection | undefined>(undefined)
 
   let connectorList: Array<Connector> = []
   let actionList: Array<HTTPBridge> = []

--- a/src/views/A2A/A2ACardRegister.vue
+++ b/src/views/A2A/A2ACardRegister.vue
@@ -108,7 +108,7 @@ const { isOpNsResourceDisabled } = useNsResource()
 const isEdit = computed(() => route.name === 'a2a-registry-edit')
 const routeNamespace = computed(() => {
   const namespace = route.query.ns
-  return typeof namespace === 'string' && namespace !== GLOBAL_NAMESPACE ? namespace : undefined
+  return typeof namespace === 'string' ? namespace : undefined
 })
 const isOpNsDisabled = computed(
   () => isEdit.value && isOpNsResourceDisabled({ namespace: routeNamespace.value }),

--- a/src/views/A2A/A2ACards.vue
+++ b/src/views/A2A/A2ACards.vue
@@ -30,7 +30,7 @@
           <el-col v-if="isMultiTenancyEnabled && !isNamespaceUser" v-bind="SEARCH_FORM_RES_PROPS">
             <NamespaceSelect
               v-model="namespaceFilter"
-              :global="{ enable: true, value: GLOBAL_NAMESPACE }"
+              :global="{ enable: true, value: GLOBAL_NAMESPACE_VALUE }"
               @clear="handleSearch"
               @change="handleSearch"
             />
@@ -173,7 +173,7 @@
 
 <script lang="ts" setup>
 import { deleteA2ACard, getA2ARegistryConfig, listA2ACards } from '@/api/a2a'
-import { GLOBAL_NAMESPACE } from '@/common/constants'
+import { GLOBAL_NAMESPACE_VALUE, type NamespaceSelection } from '@/common/constants'
 import useMultiTenancyEnabled from '@/hooks/Config/useMultiTenancyEnabled'
 import type { A2ACardListParams, A2ACardOut } from '@/types/typeAlias'
 import { Settings } from 'lucide-vue-next'
@@ -186,8 +186,7 @@ const isMultiTenancyEnabled = useMultiTenancyEnabled()
 const { t } = useI18n()
 const tl = (key: string) => t(`A2A.${key}`)
 const isNamespaceUser = computed(() => store.getters.isNamespaceUser)
-const getNamespaceLabel = (namespace?: string) =>
-  !namespace || namespace === GLOBAL_NAMESPACE ? t('BasicConfig.global') : namespace
+const getNamespaceLabel = (namespace?: string) => (namespace ? namespace : t('BasicConfig.global'))
 const { isOpNsResourceDisabled } = useNsResource()
 const isOpNsDisabled = (row?: { namespace?: string | null }) => isOpNsResourceDisabled(row)
 
@@ -206,7 +205,7 @@ const filterParams = ref<A2ACardListParams>({
   unit_id: undefined,
   agent_id: undefined,
 })
-const namespaceFilter = ref<string | undefined>(undefined)
+const namespaceFilter = ref<NamespaceSelection | undefined>(undefined)
 const { getListNamespaceParams } = useListNsParams()
 const { getNsParams } = useNsParams()
 

--- a/src/views/Config/BasicConfig/CertsManagement.vue
+++ b/src/views/Config/BasicConfig/CertsManagement.vue
@@ -7,7 +7,7 @@
             v-if="isMultiTenancyEnabled"
             v-model="namespace"
             :clearable="false"
-            :global="{ enable: true, value: GLOBAL_NAMESPACE }"
+            :global="{ enable: true, value: GLOBAL_NAMESPACE_VALUE }"
             @change="getCertBundleList"
           />
         </div>
@@ -47,6 +47,7 @@
 </template>
 
 <script setup lang="ts">
+import { GLOBAL_NAMESPACE_VALUE, type NamespaceSelection } from '@/common/constants'
 import CertBundleDrawer from '@/components/TLSConfig/CertBundleDrawer.vue'
 import getErrorMessage from '@/common/getHTTPErrorMessage'
 import CertBundleInUseDialog, {
@@ -61,9 +62,9 @@ const isMultiTenancyEnabled = useMultiTenancyEnabled()
 
 const isLoading = ref(false)
 
-const namespace = ref<string>(GLOBAL_NAMESPACE)
+const namespace = ref<NamespaceSelection>(GLOBAL_NAMESPACE_VALUE)
 const selectedNamespace = computed(() =>
-  namespace.value === GLOBAL_NAMESPACE ? undefined : namespace.value,
+  namespace.value === GLOBAL_NAMESPACE_VALUE ? undefined : namespace.value,
 )
 
 const isDrawerShow = ref(false)
@@ -93,7 +94,7 @@ const getCertBundleList = async () => {
 }
 
 const handleSubmit = async ({ namespace: ns }: ManagedCerts) => {
-  namespace.value = ns ?? GLOBAL_NAMESPACE
+  namespace.value = ns ?? GLOBAL_NAMESPACE_VALUE
   getCertBundleList()
 }
 

--- a/src/views/Diagnose/TopicMetrics.vue
+++ b/src/views/Diagnose/TopicMetrics.vue
@@ -184,7 +184,6 @@ import {
   getTopicMetricCollections,
   resetTopicMetricCollection,
 } from '@/api/diagnose'
-import { GLOBAL_NAMESPACE } from '@/common/constants'
 import useMultiTenancyEnabled from '@/hooks/Config/useMultiTenancyEnabled'
 import type {
   TopicMetricCollection,
@@ -215,10 +214,10 @@ const createDialogVisible = ref(false)
 const createLoading = ref(false)
 
 const getNamespaceLabel = (namespace?: string | null) =>
-  !namespace || namespace === GLOBAL_NAMESPACE ? t('BasicConfig.global') : namespace
+  namespace ? namespace : t('BasicConfig.global')
 
 const getRowKey = ({ namespace, name }: TopicMetricsRow) =>
-  `${namespace || GLOBAL_NAMESPACE}::${name}`
+  namespace ? `namespace:${namespace}::${name}` : `global::${name}`
 
 const tableExpandRowKeys = computed(() =>
   topicMetricsList.value.filter(({ _expand }) => _expand).map(getRowKey),

--- a/src/views/Flow/Index.vue
+++ b/src/views/Flow/Index.vue
@@ -6,7 +6,7 @@
           <NamespaceSelect
             v-if="isMultiTenancyEnabled && !isNamespaceUser"
             v-model="selectedNamespace"
-            :global="{ enable: true, value: GLOBAL_NAMESPACE }"
+            :global="{ enable: true, value: GLOBAL_NAMESPACE_VALUE }"
             @change="handleNamespaceChange"
           />
         </el-col>
@@ -38,7 +38,11 @@
 </template>
 
 <script setup lang="ts">
-import { SEARCH_FORM_RES_PROPS as colProps } from '@/common/constants'
+import {
+  GLOBAL_NAMESPACE_VALUE,
+  SEARCH_FORM_RES_PROPS as colProps,
+  type NamespaceSelection,
+} from '@/common/constants'
 import useMultiTenancyEnabled from '@/hooks/Config/useMultiTenancyEnabled'
 import FlowView from './components/FlowView.vue'
 
@@ -62,19 +66,14 @@ const getImgSrc = () => {
 const isLoading = ref(true)
 const hasFlowData = ref(true)
 
-const selectedNamespace = ref<string | undefined>(undefined)
+const selectedNamespace = ref<NamespaceSelection | undefined>(undefined)
 const isNamespaceUser = computed(() => store.getters.isNamespaceUser)
 
 const showHeader = computed(() => {
   return !isNamespaceUser.value || (isNamespaceUser.value && hasFlowData.value)
 })
 const showEmpty = computed(() => {
-  return (
-    !isNamespaceUser.value &&
-    selectedNamespace.value &&
-    selectedNamespace.value !== GLOBAL_NAMESPACE &&
-    !hasFlowData.value
-  )
+  return !isNamespaceUser.value && typeof selectedNamespace.value === 'string' && !hasFlowData.value
 })
 
 const handleNamespaceChange = () => {

--- a/src/views/Flow/components/FlowView.vue
+++ b/src/views/Flow/components/FlowView.vue
@@ -24,13 +24,14 @@
 </template>
 
 <script setup lang="ts">
+import type { NamespaceSelection } from '@/common/constants'
 import { Node, NodeMouseEvent, VueFlow } from '@vue-flow/core'
 import FlowNode from './FlowNode.vue'
 import FlowSelectDialog from './FlowSelectDialog.vue'
 import NodeDrawer from './NodeDrawer.vue'
 
 const props = defineProps<{
-  namespace: string
+  namespace?: NamespaceSelection
 }>()
 
 const router = useRouter()

--- a/src/views/General/APIKey.vue
+++ b/src/views/General/APIKey.vue
@@ -58,7 +58,7 @@
         :sort-by="({ namespace }) => namespace || ''"
       >
         <template #default="{ row }">
-          {{ row.namespace && row.namespace !== GLOBAL_NAMESPACE ? row.namespace : '' }}
+          {{ row.namespace || '' }}
         </template>
       </el-table-column>
       <el-table-column prop="desc" :label="t('Base.note')" />
@@ -95,7 +95,6 @@
 import { APIKey, APIKeyFormWhenEditing } from '@/types/systemModule'
 import APIKeyDialog, { OperationType } from './components/APIKeyDialog.vue'
 import { deleteAPIKey, loadAPIKeyList, updateAPIKey } from '@/api/systemModule'
-import { GLOBAL_NAMESPACE } from '@/common/constants'
 import dayjs from 'dayjs'
 import useMultiTenancyEnabled from '@/hooks/Config/useMultiTenancyEnabled'
 import { hasSelectedScopes, isUnsetScopes } from '@/common/scopes'

--- a/src/views/General/Backup.vue
+++ b/src/views/General/Backup.vue
@@ -7,7 +7,7 @@
           v-model="selectedNamespace"
           class="namespace-select"
           :clearable="false"
-          :global="{ enable: true, value: GLOBAL_NAMESPACE }"
+          :global="{ enable: true, value: GLOBAL_NAMESPACE_VALUE }"
           @change="handleNamespaceChanged"
         />
       </div>
@@ -74,6 +74,7 @@
 </template>
 
 <script setup lang="ts">
+import { GLOBAL_NAMESPACE_VALUE, type NamespaceSelection } from '@/common/constants'
 import {
   createBackup,
   deleteBackup,
@@ -106,7 +107,7 @@ const createLoading = ref(false)
 const uploading = ref(false)
 const backupList = ref<BackupItem[]>([])
 const UploadRef = ref<UploadInstance>()
-const selectedNamespace = ref<string | undefined>(GLOBAL_NAMESPACE)
+const selectedNamespace = ref<NamespaceSelection | undefined>(GLOBAL_NAMESPACE_VALUE)
 const uploadingNamespace = ref<string | undefined>()
 
 const store = useStore()
@@ -115,7 +116,7 @@ const isGlobalAdmin = computed(
   () => !isNamespaceUser.value && store.state.user.role === UserRole.Admin,
 )
 const namespaceParam = computed(() =>
-  selectedNamespace.value === GLOBAL_NAMESPACE ? undefined : selectedNamespace.value,
+  selectedNamespace.value === GLOBAL_NAMESPACE_VALUE ? undefined : selectedNamespace.value,
 )
 const isNamespaceBackupView = computed(
   () => isGlobalAdmin.value && namespaceParam.value !== undefined,

--- a/src/views/General/Users.vue
+++ b/src/views/General/Users.vue
@@ -73,7 +73,7 @@
         :sort-by="({ namespace }) => namespace || ''"
       >
         <template #default="{ row }">
-          {{ row.namespace && row.namespace !== GLOBAL_NAMESPACE ? row.namespace : '' }}
+          {{ row.namespace || '' }}
         </template>
       </el-table-column>
       <el-table-column :label="$t('Base.operation')" :min-width="isZh ? 308 : 386">
@@ -296,7 +296,7 @@
 <script setup>
 import { changePassword, createUser, destroyUser, loadUser, updateUser } from '@/api/function.ts'
 import { getLoginUserScopes } from '@/api/systemModule.ts'
-import { DASHBOARD_USERNAME_REG, GLOBAL_NAMESPACE } from '@/common/constants'
+import { DASHBOARD_USERNAME_REG } from '@/common/constants'
 import { hasSelectedScopes, isUnsetScopes, normalizeScopes, UNSET_SCOPES } from '@/common/scopes'
 import { UserRole } from '@/types/enum.ts'
 import useMultiTenancyEnabled from '@/hooks/Config/useMultiTenancyEnabled'
@@ -690,7 +690,7 @@ const showDialog = (type = 'create', item = {}) => {
   } else {
     record.value = generateRawForm()
   }
-  isNamespaceEnabled.value = !!record.value.namespace && record.value.namespace !== GLOBAL_NAMESPACE
+  isNamespaceEnabled.value = !!record.value.namespace
   if (type === 'edit') {
     if (availableUserScopes.value.length > 0) {
       resolveRoleDefaultScopeState()
@@ -724,11 +724,7 @@ const trimUserName = () => {
 const getBackend = (backend) => (backend === SOURCE_LOCAL ? undefined : backend)
 
 const getRecordForUpdating = () => {
-  const normalizedRecord = {
-    ...record.value,
-    namespace: record.value.namespace === GLOBAL_NAMESPACE ? '' : record.value.namespace,
-  }
-  const ret = processUserRecordForSubmit(normalizedRecord)
+  const ret = processUserRecordForSubmit(record.value)
   return buildUserPayload(ret, ['description', 'role', 'scopes'])
 }
 // Both the global role-default radio and the namespace role-default switch

--- a/src/views/General/components/APIKeyDialog.vue
+++ b/src/views/General/components/APIKeyDialog.vue
@@ -207,7 +207,6 @@
 <script lang="ts" setup>
 import { createAPIKey, updateAPIKey, getAPIKeyScopes } from '@/api/systemModule'
 import { UserRole } from '@/types/enum'
-import { GLOBAL_NAMESPACE } from '@/common/constants'
 import { APIKey, APIKeyFormWhenCreating, APIKeyScope } from '@/types/systemModule'
 import { isUnsetScopes, normalizeScopes, UNSET_SCOPES } from '@/common/scopes'
 import APIKeyResultDialog from './APIKeyResultDialog.vue'
@@ -222,7 +221,7 @@ enum ScopeMode {
 
 const SYSTEM_SCOPE = 'system'
 const PUBLISH_SCOPE = 'publish'
-const isNamespacedNamespace = (namespace?: string) => !!namespace && namespace !== GLOBAL_NAMESPACE
+const isNamespacedNamespace = (namespace?: string) => !!namespace
 
 type APIKeyFormData = Omit<APIKeyFormWhenCreating, 'scopes'> &
   Partial<Omit<APIKey, 'scopes'>> & {
@@ -450,8 +449,7 @@ watch(showDialog, async (val) => {
       lastRole.value = formData.value.role as UserRole
       formCom.value.clearValidate()
     }
-    isNamespaceEnabled.value =
-      !!formData.value.namespace && formData.value.namespace !== GLOBAL_NAMESPACE
+    isNamespaceEnabled.value = !!formData.value.namespace
   } else {
     formData.value = createRawFormData()
     originalAPIKeyScopeState.value = undefined

--- a/src/views/RuleEngine/Bridge/Components/ConnectorSelect.vue
+++ b/src/views/RuleEngine/Bridge/Components/ConnectorSelect.vue
@@ -67,7 +67,7 @@ const { getListNamespaceParams } = useListNsParams()
 const totalConnectorList = ref<Array<Connector>>([])
 const getTotalList = async () => {
   try {
-    const selectedNamespace = !isNamespaceUser.value ? GLOBAL_NAMESPACE : undefined
+    const selectedNamespace = !isNamespaceUser.value ? GLOBAL_NAMESPACE_VALUE : undefined
     totalConnectorList.value = await getConnectors(getListNamespaceParams(selectedNamespace))
   } catch (error) {
     //

--- a/src/views/RuleEngine/Connector/Connector.vue
+++ b/src/views/RuleEngine/Connector/Connector.vue
@@ -9,7 +9,7 @@
                 v-if="isMultiTenancyEnabled && !isNamespaceUser"
                 v-model="namespaceFilter"
                 :placeholder="t('BasicConfig.namespace')"
-                :global="{ enable: true, value: GLOBAL_NAMESPACE }"
+                :global="{ enable: true, value: GLOBAL_NAMESPACE_VALUE }"
                 @clear="getList"
                 @change="getList"
               />
@@ -165,7 +165,11 @@
 
 <script setup lang="ts">
 import { BridgeType, ConnectionStatus } from '@/types/enum'
-import { SEARCH_FORM_RES_PROPS as colProps } from '@/common/constants'
+import {
+  GLOBAL_NAMESPACE_VALUE,
+  SEARCH_FORM_RES_PROPS as colProps,
+  type NamespaceSelection,
+} from '@/common/constants'
 import useMultiTenancyEnabled from '@/hooks/Config/useMultiTenancyEnabled'
 import { BridgeItem, Connector } from '@/types/rule'
 import { Setting } from '@element-plus/icons-vue'
@@ -188,7 +192,7 @@ const isLoading = ref<boolean>(false)
 const tableData = ref<Array<Connector | BridgeItem>>([])
 
 const namespaceFromRoute = route.query.ns
-const namespaceFilter = ref<string | undefined>(
+const namespaceFilter = ref<NamespaceSelection | undefined>(
   typeof namespaceFromRoute === 'string' ? namespaceFromRoute : undefined,
 )
 

--- a/src/views/RuleEngine/Rule/components/RuleFilterForm.vue
+++ b/src/views/RuleEngine/Rule/components/RuleFilterForm.vue
@@ -59,7 +59,7 @@
             <NamespaceSelect
               v-model="filterParams.ns"
               :placeholder="t('BasicConfig.namespace')"
-              :global="{ enable: true, value: GLOBAL_NAMESPACE }"
+              :global="{ enable: true, value: GLOBAL_NAMESPACE_VALUE }"
               @clear="searchRule"
             />
           </el-form-item>
@@ -125,9 +125,17 @@
 </template>
 
 <script setup lang="ts">
-import { SEARCH_FORM_RES_PROPS as colProps } from '@/common/constants'
+import {
+  GLOBAL_NAMESPACE_VALUE,
+  SEARCH_FORM_RES_PROPS as colProps,
+  type NamespaceSelection,
+} from '@/common/constants'
 import useMultiTenancyEnabled from '@/hooks/Config/useMultiTenancyEnabled'
 import { FilterParamsForQueryRules } from '@/types/rule'
+
+type RuleFilterFormParams = Omit<FilterParamsForQueryRules, 'ns'> & {
+  ns?: NamespaceSelection
+}
 
 const props = defineProps({
   initialValue: {
@@ -172,7 +180,7 @@ const emit = defineEmits(['search', 'refresh'])
 
 const showMoreQuery = ref(false)
 
-const filterParams: Ref<FilterParamsForQueryRules> = ref(createRawFilterParams())
+const filterParams: Ref<RuleFilterFormParams> = ref(createRawFilterParams())
 const keyForSearchTopic: Ref<'like_from' | 'match_from'> = ref(KEYS_FOR_SEARCH_TOPIC[0].value)
 const keyForFilterActionOrSource: Ref<Endpoint> = ref(FILTER_ACTION_OR_SOURCE_OPTIONS[0].value)
 
@@ -221,7 +229,7 @@ const getFilterParams = () => {
   ).reduce((obj, currentKey) => {
     const currentVal = filterParamsData[currentKey]
     if (currentKey === 'ns') {
-      return { ...obj, ...getListNamespaceParams(currentVal as string | undefined) }
+      return { ...obj, ...getListNamespaceParams(currentVal as NamespaceSelection | undefined) }
     } else if (currentVal !== undefined && currentVal !== '') {
       return { ...obj, [currentKey]: currentVal }
     }

--- a/src/views/RuleEngine/components/ActionAndSourceFilterForm.vue
+++ b/src/views/RuleEngine/components/ActionAndSourceFilterForm.vue
@@ -67,7 +67,7 @@
             <NamespaceSelect
               v-model="filterParams.namespace"
               :placeholder="t('BasicConfig.namespace')"
-              :global="{ enable: true, value: GLOBAL_NAMESPACE }"
+              :global="{ enable: true, value: GLOBAL_NAMESPACE_VALUE }"
               @clear="search"
               @change="search"
             />
@@ -96,7 +96,11 @@
 </template>
 
 <script setup lang="ts">
-import { SEARCH_FORM_RES_PROPS as colProps } from '@/common/constants'
+import {
+  GLOBAL_NAMESPACE_VALUE,
+  SEARCH_FORM_RES_PROPS as colProps,
+  type NamespaceSelection,
+} from '@/common/constants'
 import useMultiTenancyEnabled from '@/hooks/Config/useMultiTenancyEnabled'
 import { ConnectionStatus } from '@/types/enum'
 
@@ -106,7 +110,7 @@ interface ActionAndSourceFilterParams {
   status?: ConnectionStatus
   rules?: string
   enable?: boolean
-  namespace?: string
+  namespace?: NamespaceSelection
 }
 
 const props = defineProps<{
@@ -157,7 +161,7 @@ const getFilterParams = (): Record<string, string | boolean> => {
           return { ...obj, [currentKey]: new RegExp(`^${escapeRegExp(currentVal as string)}$`) }
         }
         if (currentKey === 'namespace') {
-          if (currentVal === GLOBAL_NAMESPACE) {
+          if (currentVal === GLOBAL_NAMESPACE_VALUE) {
             return { ...obj, namespace: null }
           } else if (currentVal) {
             return { ...obj, namespace: currentVal }

--- a/src/views/Webhook/Webhook.vue
+++ b/src/views/Webhook/Webhook.vue
@@ -8,7 +8,7 @@
               v-if="isMultiTenancyEnabled && !isNamespaceUser"
               v-model="namespaceFilter"
               :placeholder="t('BasicConfig.namespace')"
-              :global="{ enable: true, value: GLOBAL_NAMESPACE }"
+              :global="{ enable: true, value: GLOBAL_NAMESPACE_VALUE }"
               @change="getWebhookList"
             />
           </el-col>


### PR DESCRIPTION
- use a numeric UI sentinel for the global namespace selector option
- preserve managed namespaces named global across filters and routes
- handle global-named users and API keys as namespaced resources
- update namespace selection types across affected resource views

fixes https://github.com/emqx/emqx-dashboard5/issues/3906