### PR TITLE
feat(backup): support security profile mismatch override

### DIFF
--- a/src/i18n/General.ts
+++ b/src/i18n/General.ts
@@ -605,6 +605,14 @@ Available scopes are still restricted by the user's role. The default scopes for
     zh: '确认使用当前备份恢复命名空间 {namespace}？',
     en: 'Restore namespace {namespace} from this backup?',
   },
+  allowSecurityProfileMismatch: {
+    zh: '允许安全配置文件不匹配',
+    en: 'Allow Security Profile Mismatch',
+  },
+  securityProfileMismatchWarning: {
+    zh: '将 legacy 或旧版备份恢复到 hardened 节点后，监听器可访问性、客户端认证、Dashboard 登录以及认证或授权故障的处理方式可能发生变化。请仅在审查并接受这些风险后启用此选项。',
+    en: 'Restoring a legacy or older backup to a hardened node may change listener accessibility, client authentication, Dashboard login, and authentication or authorization failure handling. Enable this option only after reviewing and accepting these risks.',
+  },
   restoreSuccess: {
     zh: '恢复成功',
     en: 'Restore successfully',

--- a/src/style/normalize.scss
+++ b/src/style/normalize.scss
@@ -788,10 +788,6 @@
 .el-message-box__status + .el-message-box__message {
   line-height: 1.4;
 }
-.backup-restore-confirm .el-message-box__message {
-  min-width: 0;
-  overflow-wrap: anywhere;
-}
 
 /* Notification */
 .el-notification {

--- a/src/types/schemas/dataBackup.schemas.ts
+++ b/src/types/schemas/dataBackup.schemas.ts
@@ -194,6 +194,7 @@ export interface PublicMeta {
 }
 
 export interface EmqxMgmtApiDataBackupImportRequestBody {
+  allow_security_profile_mismatch?: boolean
   filename: string
   node?: string
 }

--- a/src/views/General/Backup.vue
+++ b/src/views/General/Backup.vue
@@ -70,6 +70,13 @@
     <div class="emq-table-footer">
       <common-pagination @loadPage="loadBackupFiles" v-model:metaData="pageMeta" />
     </div>
+    <BackupRestoreDialog
+      v-model="restoreDialogVisible"
+      :namespace="restoringNamespace"
+      :loading="restoreLoading"
+      @confirm="confirmRestoreBackup"
+      @cancel="cancelRestoreBackup"
+    />
   </div>
 </template>
 
@@ -87,6 +94,7 @@ import { PageData } from '@/types/common'
 import { UserRole } from '@/types/enum'
 import { EmqxMgmtApiDataBackupBackupFileInfo } from '@/types/schemas/dataBackup.schemas'
 import NamespaceSelect from '@/components/Namespace/NamespaceSelect.vue'
+import BackupRestoreDialog from './components/BackupRestoreDialog.vue'
 import { createDownloadBlobLink, formatSizeUnit } from '@emqx/shared-ui-utils'
 import dayjs from 'dayjs'
 import {
@@ -109,6 +117,10 @@ const backupList = ref<BackupItem[]>([])
 const UploadRef = ref<UploadInstance>()
 const selectedNamespace = ref<NamespaceSelection | undefined>(GLOBAL_NAMESPACE_VALUE)
 const uploadingNamespace = ref<string | undefined>()
+const restoreDialogVisible = ref(false)
+const restoreLoading = ref(false)
+const backupToRestore = ref<BackupItem>()
+const restoringNamespace = ref<string | undefined>()
 
 const store = useStore()
 const isNamespaceUser = computed(() => store.getters.isNamespaceUser)
@@ -165,40 +177,41 @@ const handleCreateBackup = async () => {
   }
 }
 
-const handleRestoreBackup = async (backup: BackupItem) => {
-  const targetNamespace = namespaceParam.value
-  const confirmMessage = targetNamespace
-    ? tl('confirmNamespaceRestore', { namespace: targetNamespace })
-    : tl('confirmRestore')
-  ElMessageBox.confirm(confirmMessage, {
-    confirmButtonText: t('Base.confirm'),
-    cancelButtonText: t('Base.cancel'),
-    customClass: 'backup-restore-confirm',
-    type: 'info',
-    beforeClose: async (action, instance, done) => {
-      if (action === 'confirm') {
-        instance.confirmButtonLoading = true
-        try {
-          const { filename, node } = backup
-          await restoreBackup(
-            { filename, node },
-            targetNamespace ? { namespace: targetNamespace } : undefined,
-          )
-          ElMessage.success(
-            targetNamespace
-              ? tl('namespaceRestoreSuccess', { namespace: targetNamespace })
-              : tl('restoreSuccess'),
-          )
-          done()
-        } catch (error) {
-          done()
-        }
-      } else {
-        store.commit('CLEAR_ABORT_CONTROLLERS')
-        done()
-      }
-    },
-  })
+const handleRestoreBackup = (backup: BackupItem) => {
+  backupToRestore.value = backup
+  restoringNamespace.value = namespaceParam.value
+  restoreDialogVisible.value = true
+}
+
+const confirmRestoreBackup = async (allowSecurityProfileMismatch: boolean) => {
+  if (!backupToRestore.value) {
+    return
+  }
+  const { filename, node } = backupToRestore.value
+  const payload = allowSecurityProfileMismatch
+    ? { filename, node, allow_security_profile_mismatch: true }
+    : { filename, node }
+  try {
+    restoreLoading.value = true
+    await restoreBackup(
+      payload,
+      restoringNamespace.value ? { namespace: restoringNamespace.value } : undefined,
+    )
+    ElMessage.success(
+      restoringNamespace.value
+        ? tl('namespaceRestoreSuccess', { namespace: restoringNamespace.value })
+        : tl('restoreSuccess'),
+    )
+    restoreDialogVisible.value = false
+  } catch (error) {
+    // Keep the dialog open so the operator can review and retry.
+  } finally {
+    restoreLoading.value = false
+  }
+}
+
+const cancelRestoreBackup = () => {
+  store.commit('CLEAR_ABORT_CONTROLLERS')
 }
 
 const handleDeleteBackup = async ({ filename, node }: BackupItem) => {

--- a/src/views/General/components/BackupRestoreDialog.vue
+++ b/src/views/General/components/BackupRestoreDialog.vue
@@ -1,0 +1,91 @@
+<template>
+  <el-dialog
+    v-model="showDialog"
+    align-center
+    destroy-on-close
+    width="600px"
+    :title="tl('restore')"
+    :show-close="false"
+    :close-on-click-modal="false"
+    :close-on-press-escape="false"
+  >
+    <p class="restore-confirm-message">{{ confirmMessage }}</p>
+    <el-checkbox v-model="allowSecurityProfileMismatch">
+      {{ tl('allowSecurityProfileMismatch') }}
+    </el-checkbox>
+    <TipContainer
+      v-if="allowSecurityProfileMismatch"
+      class="security-profile-mismatch-warning"
+      :content="tl('securityProfileMismatchWarning')"
+    />
+    <template #footer>
+      <div class="dialog-align-footer">
+        <CancelButton @click="cancel" />
+        <el-button
+          type="primary"
+          :disabled="!$hasPermission('post')"
+          :loading="loading"
+          @click="confirm"
+        >
+          {{ t('Base.confirm') }}
+        </el-button>
+      </div>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  modelValue: boolean
+  namespace?: string
+  loading?: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', val: boolean): void
+  (e: 'confirm', allowSecurityProfileMismatch: boolean): void
+  (e: 'cancel'): void
+}>()
+
+const { t, tl } = useI18nTl('General')
+
+const showDialog = computed({
+  get: () => props.modelValue,
+  set: (val: boolean) => emit('update:modelValue', val),
+})
+
+const allowSecurityProfileMismatch = ref(false)
+const confirmMessage = computed(() =>
+  props.namespace
+    ? tl('confirmNamespaceRestore', { namespace: props.namespace })
+    : tl('confirmRestore'),
+)
+
+watch(
+  () => props.modelValue,
+  (visible) => {
+    if (visible) {
+      allowSecurityProfileMismatch.value = false
+    }
+  },
+)
+
+const cancel = () => {
+  showDialog.value = false
+  emit('cancel')
+}
+
+const confirm = () => {
+  emit('confirm', allowSecurityProfileMismatch.value)
+}
+</script>
+
+<style lang="scss" scoped>
+.restore-confirm-message {
+  margin: 0 0 16px;
+}
+
+.security-profile-mismatch-warning {
+  margin-top: 12px;
+}
+</style>


### PR DESCRIPTION
- add a dedicated restore dialog with an explicit mismatch opt-in and risk warning
- send allow_security_profile_mismatch only when enabled by the operator
- keep the dialog open after failed restores and support namespace-scoped imports
- update backup API types and translations

closes #3926 