### PR TITLE
fix(topic metrics): block unsupported topic filters

### DIFF
--- a/src/hooks/Diagnose/useTopicMetrics.ts
+++ b/src/hooks/Diagnose/useTopicMetrics.ts
@@ -1,0 +1,12 @@
+const UNSUPPORTED_TOPIC_METRICS_FILTER_REG = /^\$(share|queue)\//
+
+const useTopicMetrics = () => {
+  const isTopicCanCreateMetrics = (topic: string) =>
+    !UNSUPPORTED_TOPIC_METRICS_FILTER_REG.test(topic.trim())
+
+  return {
+    isTopicCanCreateMetrics,
+  }
+}
+
+export default useTopicMetrics

--- a/src/i18n/Subs.ts
+++ b/src/i18n/Subs.ts
@@ -15,4 +15,8 @@ export default {
     zh: '创建监控',
     en: 'Create Monitor',
   },
+  topicMetricsFilterNotSupported: {
+    zh: '主题监控不支持 `$share/` 或 `$queue/` 主题过滤器',
+    en: 'Topic Metrics does not support `$share/` or `$queue/` topic filters',
+  },
 }

--- a/src/views/Diagnose/TopicMetrics.vue
+++ b/src/views/Diagnose/TopicMetrics.vue
@@ -184,6 +184,7 @@ import {
   getTopicMetricCollections,
   resetTopicMetricCollection,
 } from '@/api/diagnose'
+import useTopicMetrics from '@/hooks/Diagnose/useTopicMetrics'
 import useMultiTenancyEnabled from '@/hooks/Config/useMultiTenancyEnabled'
 import type {
   TopicMetricCollection,
@@ -336,6 +337,7 @@ const createForm = reactive<TopicMetricCollectionCreate>({
 })
 
 const { createRequiredRule, createMqttSubscribeTopicRule } = useFormRules()
+const { isTopicCanCreateMetrics } = useTopicMetrics()
 const createRules: FormRules = {
   name: [
     ...createRequiredRule(tl('topicMetricsName')),
@@ -345,7 +347,19 @@ const createRules: FormRules = {
       trigger: 'blur',
     },
   ],
-  topic_filter: [...createRequiredRule(tl('topicFilter')), ...createMqttSubscribeTopicRule()],
+  topic_filter: [
+    ...createRequiredRule(tl('topicFilter')),
+    ...createMqttSubscribeTopicRule(),
+    {
+      validator(_rule, value: string) {
+        if (!value || isTopicCanCreateMetrics(value)) {
+          return []
+        }
+        return [new Error(t('Subs.topicMetricsFilterNotSupported'))]
+      },
+      trigger: 'blur',
+    },
+  ],
 }
 
 const openCreateDialog = (topicFilter = '') => {

--- a/src/views/Topics/Topics.vue
+++ b/src/views/Topics/Topics.vue
@@ -30,7 +30,17 @@
         <el-table-column prop="node" :label="$t('Clients.node')" />
         <el-table-column v-if="isMetricsEnabled" :label="$t('Base.operation')">
           <template #default="{ row }">
+            <el-tooltip
+              v-if="!isTopicCanCreateMetrics(row.topic)"
+              effect="dark"
+              :content="tl('topicMetricsFilterNotSupported')"
+            >
+              <span>
+                <TableButton disabled>{{ tl('addMetric') }}</TableButton>
+              </span>
+            </el-tooltip>
             <TableButton
+              v-else
               :disabled="!$hasPermission('post')"
               @click="createMetricForTopic(row.topic)"
             >
@@ -54,6 +64,7 @@ export default defineComponent({
 
 <script lang="ts" setup>
 import { listTopics } from '@/api/common'
+import useTopicMetrics from '@/hooks/Diagnose/useTopicMetrics'
 import { FeatureName } from '@/types/enum'
 import CommonPagination from '../../components/commonPagination.vue'
 
@@ -68,6 +79,7 @@ const tableData = ref([])
 const searchValue = ref('')
 const lockTable = ref(true)
 const params = ref<Record<string, any>>({})
+const { isTopicCanCreateMetrics } = useTopicMetrics()
 
 const { pageMeta, pageParams, initPageMeta, setPageMeta } = usePaginationWithHasNext()
 


### PR DESCRIPTION
- disable metric creation for $share/ and $queue/ topic filters
- validate filters in the creation form to prevent bypassing the topic list guard
- add localized guidance for unsupported filters

fixes #3928 