### PR TITLE
fix(security): protect external links opened in new tabs

### DIFF
--- a/src/components/BatchSettings.vue
+++ b/src/components/BatchSettings.vue
@@ -20,7 +20,9 @@
               <li>{{ $t('Base.batchSettingDownloadFirst') }}</li>
               <i18n-t keypath="Base.moreImportInstructions" tag="li">
                 <template #link>
-                  <a :href="checkDocMap[type]" target="_blank">{{ $t('Base.helpDocs') }}</a>
+                  <a :href="checkDocMap[type]" target="_blank" rel="noopener noreferrer">
+                    {{ $t('Base.helpDocs') }}
+                  </a>
                 </template>
               </i18n-t>
             </ul>

--- a/src/components/LicensePromotion.vue
+++ b/src/components/LicensePromotion.vue
@@ -3,13 +3,23 @@
     <span class="promo-text">
       {{ t('Base.promoCommunityEdition') }}
       {{ t('Base.promoApplyFor') }}
-      <a :href="applyLicenseUrl" target="_blank" class="header-action-link">{{
-        t('Base.promoLicenseText')
-      }}</a>
+      <a
+        :href="applyLicenseUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="header-action-link"
+      >
+        {{ t('Base.promoLicenseText') }}
+      </a>
       {{ t('Base.promoOrTry') }}
-      <a :href="cloudServiceUrl" target="_blank" class="header-action-link">{{
-        t('Base.promoManagedServiceText')
-      }}</a>
+      <a
+        :href="cloudServiceUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="header-action-link"
+      >
+        {{ t('Base.promoManagedServiceText') }}
+      </a>
     </span>
     <el-icon class="close-promo-icon" @click="dismiss">
       <Close />

--- a/src/components/MarkdownContent.vue
+++ b/src/components/MarkdownContent.vue
@@ -19,7 +19,10 @@
 <script setup lang="ts">
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { marked } from 'marked'
-import xss from 'xss'
+import xss, { getDefaultWhiteList } from 'xss'
+
+const xssWhiteList = getDefaultWhiteList()
+xssWhiteList.a = [...(xssWhiteList.a ?? []), 'rel']
 
 interface TocItem {
   title: string
@@ -96,7 +99,7 @@ const setEle = (val: string | undefined) => {
   if (!val) {
     containerEle.value.innerHTML = ''
   } else {
-    containerEle.value.innerHTML = xss(convertMarkdown(val))
+    containerEle.value.innerHTML = xss(convertMarkdown(val), { whiteList: xssWhiteList })
   }
 }
 

--- a/src/i18n/RuleEngine.ts
+++ b/src/i18n/RuleEngine.ts
@@ -1026,12 +1026,12 @@ If any other timestamp is used, its precision must exactly match the value chose
 It's recommended to use a template syntax, e.g., \`\${'{'}timestamp{'}'}\` or \`\${'{'}payload.timestamp{'}'}\`, to write an {database} data record for each message.`,
   },
   influxdbFieldValueDesc: {
-    zh: `键值对都支持占位符。数字默认写成浮点数，可以添加一个类型后缀来指定一个类型（例如：\`\${'{'}payload.int_key{'}'}i\`），详情可查看 <a href="https://docs.influxdata.com/influxdb/v1.8/write_protocols/line_protocol_tutorial/#data-types" target="_blank">InfluxDB line protocol tutorial</a>`,
-    en: `Both key and value support placeholders. Numbers are written as floats by default, but you can add a type suffix to specify a type (e.g. \`\${'{'}payload.int_key{'}'}i\`). Learn more in the <a href="https://docs.influxdata.com/influxdb/v1.8/write_protocols/line_protocol_tutorial/#data-types" target="_blank">InfluxDB line protocol tutorial</a>`,
+    zh: `键值对都支持占位符。数字默认写成浮点数，可以添加一个类型后缀来指定一个类型（例如：\`\${'{'}payload.int_key{'}'}i\`），详情可查看 <a href="https://docs.influxdata.com/influxdb/v1.8/write_protocols/line_protocol_tutorial/#data-types" target="_blank" rel="noopener noreferrer">InfluxDB line protocol tutorial</a>`,
+    en: `Both key and value support placeholders. Numbers are written as floats by default, but you can add a type suffix to specify a type (e.g. \`\${'{'}payload.int_key{'}'}i\`). Learn more in the <a href="https://docs.influxdata.com/influxdb/v1.8/write_protocols/line_protocol_tutorial/#data-types" target="_blank" rel="noopener noreferrer">InfluxDB line protocol tutorial</a>`,
   },
   datalayersFieldValueDesc: {
-    zh: `键值对都支持占位符。数字默认写成浮点数，可以添加一个类型后缀来指定一个类型（例如：\`\${'{'}payload.int_key{'}'}i\`），详情可查看 <a href="https://docs.datalayers.cn/datalayers/latest/development-guide/writing-with-influxdb-line-protocol.html" target="_blank">InfluxDB line protocol tutorial</a>`,
-    en: `Both key and value support placeholders. Numbers are written as floats by default, but you can add a type suffix to specify a type (e.g. \`\${'{'}payload.int_key{'}'}i\`). Learn more in the <a href="https://docs.datalayers.cn/datalayers/latest/development-guide/writing-with-influxdb-line-protocol.html" target="_blank">InfluxDB line protocol tutorial</a>`,
+    zh: `键值对都支持占位符。数字默认写成浮点数，可以添加一个类型后缀来指定一个类型（例如：\`\${'{'}payload.int_key{'}'}i\`），详情可查看 <a href="https://docs.datalayers.cn/datalayers/latest/development-guide/writing-with-influxdb-line-protocol.html" target="_blank" rel="noopener noreferrer">InfluxDB line protocol tutorial</a>`,
+    en: `Both key and value support placeholders. Numbers are written as floats by default, but you can add a type suffix to specify a type (e.g. \`\${'{'}payload.int_key{'}'}i\`). Learn more in the <a href="https://docs.datalayers.cn/datalayers/latest/development-guide/writing-with-influxdb-line-protocol.html" target="_blank" rel="noopener noreferrer">InfluxDB line protocol tutorial</a>`,
   },
   dataFormat: {
     zh: '数据格式',

--- a/src/i18n/RuleSyntax.ts
+++ b/src/i18n/RuleSyntax.ts
@@ -672,8 +672,8 @@ export default {
     en: 'Decomposed string array',
   },
   sprintfDesc: {
-    zh: '字符串格式化，格式字符串的用法详见 <a href="https://erlang.org/doc/man/io.html#fwrite-1" target="_blank">https://erlang.org/doc/man/io.html#fwrite-1</a> 里的 Format 部分',
-    en: 'String formatting, see the Format section in <a href="https://erlang.org/doc/man/io.html#fwrite-1" target="_blank">https://erlang.org/doc/man/io.html#fwrite-1</a> for usage',
+    zh: '字符串格式化，格式字符串的用法详见 <a href="https://erlang.org/doc/man/io.html#fwrite-1" target="_blank" rel="noopener noreferrer">https://erlang.org/doc/man/io.html#fwrite-1</a> 里的 Format 部分',
+    en: 'String formatting, see the Format section in <a href="https://erlang.org/doc/man/io.html#fwrite-1" target="_blank" rel="noopener noreferrer">https://erlang.org/doc/man/io.html#fwrite-1</a> for usage',
   },
   sprintfParams: {
     zh: '1. 格式字符串 <br />2,3,4... 参数列表。参数个数不定',

--- a/src/views/Base/LicenseTipDialog.vue
+++ b/src/views/Base/LicenseTipDialog.vue
@@ -29,7 +29,9 @@
         </template>
       </template>
       <i18n-t v-else class="tip" keypath="Dashboard.licenseExpiryTip" tag="p" scope="global">
-        <a :href="docMap.applyLicense" target="_blank">{{ tl('updateLicense') }}</a>
+        <a :href="docMap.applyLicense" target="_blank" rel="noopener noreferrer">
+          {{ tl('updateLicense') }}
+        </a>
       </i18n-t>
     </div>
     <template #footer>
@@ -96,7 +98,7 @@ const isLicenseExpiry = computed(() => license.value.expiry)
 const licenseTipWidth = computed(() => (isLicenseExpiry.value ? 600 : 580))
 const isCommunityLicense = computed(() => store.getters.isCommunityLicense)
 
-const appleLicenseLink = `<a href="${docMap.applyLicense}" target="_blank">${tl('licenseApply')}</a>`
+const appleLicenseLink = `<a href="${docMap.applyLicense}" target="_blank" rel="noopener noreferrer">${tl('licenseApply')}</a>`
 
 const router = useRouter()
 const goLicense = () => {

--- a/src/views/Config/Monitoring/MonitoringIntegration.vue
+++ b/src/views/Config/Monitoring/MonitoringIntegration.vue
@@ -86,7 +86,7 @@
                           <a
                             href="https://prometheus.io/docs/practices/pushing/#when-to-use-the-pushgateway"
                             target="_blank"
-                            rel="noopener"
+                            rel="noopener noreferrer"
                           >
                             {{ tl('whenToUsePushgateway') }}
                           </a>
@@ -297,10 +297,12 @@
           <el-form-item v-if="selectedPlatform === DATADOG">
             <i18n-t keypath="MonitoringIntegration.dataDogTip" tag="p" class="tip">
               <template #docUse>
-                <a :href="docMap.documentation" target="_blank">{{ tl('thisDoc') }}</a>
+                <a :href="docMap.documentation" target="_blank" rel="noopener noreferrer">
+                  {{ tl('thisDoc') }}
+                </a>
               </template>
               <template #docIntegration>
-                <a :href="docMap.datadogIntegration" target="_blank">
+                <a :href="docMap.datadogIntegration" target="_blank" rel="noopener noreferrer">
                   {{ tl('datadogIntegration') }}
                 </a>
               </template>

--- a/src/views/Config/Monitoring/components/HelpDrawer.vue
+++ b/src/views/Config/Monitoring/components/HelpDrawer.vue
@@ -24,7 +24,7 @@
                     <a
                       href="https://prometheus.io/docs/guides/node-exporter/#installing-and-running-the-node-exporter"
                       target="_blank"
-                      rel="noopener"
+                      rel="noopener noreferrer"
                     >
                       {{ tl('installNodeExporter') }}
                     </a>
@@ -117,7 +117,7 @@
                   <a
                     href="https://prometheus.io/docs/guides/node-exporter/#installing-and-running-the-node-exporter"
                     target="_blank"
-                    rel="noopener"
+                    rel="noopener noreferrer"
                   >
                     {{ tl('installNodeExporter') }}
                   </a>

--- a/src/views/Dashboard/NodeDetail.vue
+++ b/src/views/Dashboard/NodeDetail.vue
@@ -29,7 +29,7 @@
               {{ transMsNumToSimpleStr(node.uptime) }}
             </el-descriptions-item>
             <el-descriptions-item :label="tl('version')">
-              <a :href="releaseNoteLink(node.version)" target="_blank">
+              <a :href="releaseNoteLink(node.version)" target="_blank" rel="noopener noreferrer">
                 {{ node.version }}
               </a>
             </el-descriptions-item>

--- a/src/views/Dashboard/components/NodesGraphCard.vue
+++ b/src/views/Dashboard/components/NodesGraphCard.vue
@@ -58,7 +58,7 @@
                 <div class="node-item">
                   <label class="node-item-label">{{ tl('version') }}: </label>
                   <span class="node-item-content">
-                    <a :href="releaseNoteLink" target="_blank">
+                    <a :href="releaseNoteLink" target="_blank" rel="noopener noreferrer">
                       {{ currentInfo.node['version'] }} ({{ $t(edition.title) }})
                     </a>
                   </span>

--- a/src/views/General/License.vue
+++ b/src/views/General/License.vue
@@ -104,7 +104,9 @@
             <el-alert v-else-if="licenseData.expiry" show-icon :closable="false" type="info">
               <template #title>
                 <i18n-t keypath="Dashboard.licenseExpiryTip" scope="global">
-                  <a :href="docMap.applyLicense" target="_blank">{{ tl('updateLicense') }}</a>
+                  <a :href="docMap.applyLicense" target="_blank" rel="noopener noreferrer">
+                    {{ tl('updateLicense') }}
+                  </a>
                 </i18n-t>
               </template>
             </el-alert>

--- a/src/views/Plugins/components/PluginInfo.vue
+++ b/src/views/Plugins/components/PluginInfo.vue
@@ -16,7 +16,12 @@
 
       <PluginInfoItem label="Repository">
         <!-- TODO:icon -->
-        <a :href="pluginData.repo" class="link-repository" target="_blank">
+        <a
+          :href="pluginData.repo"
+          class="link-repository"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           {{ pluginData.repo }}
         </a>
       </PluginInfoItem>

--- a/src/views/RuleEngine/components/RuleForm.vue
+++ b/src/views/RuleEngine/components/RuleForm.vue
@@ -32,7 +32,9 @@
                   <InfoTooltip :content="tl('ruleSQLDesc')" />
                   <p class="sub-block-desc">
                     <span>{{ tl('sqlEdit') }}</span>
-                    <a :href="docMap.sqlGrammar" target="_blank">{{ tl('sqlSyntaxAndTem') }}</a>
+                    <a :href="docMap.sqlGrammar" target="_blank" rel="noopener noreferrer">
+                      {{ tl('sqlSyntaxAndTem') }}
+                    </a>
                   </p>
                   <el-alert
                     v-if="containsAIExpression"

--- a/src/views/Settings/Help.vue
+++ b/src/views/Settings/Help.vue
@@ -8,7 +8,7 @@
   >
     <el-row class="website-links" :gutter="16">
       <el-col :span="8" v-for="{ link, icon, title } in platformList" :key="link">
-        <a :href="link" target="_blank">
+        <a :href="link" target="_blank" rel="noopener noreferrer">
           <el-card class="card-link" shadow="never">
             <img :src="icon" />
             <p class="text-title">{{ title }}</p>
@@ -20,7 +20,12 @@
       <el-col :span="24" class="flex-column">
         <template v-for="({ link, title }, $index) in emqxDocumentList" :key="link">
           <div class="text-large">
-            <a :href="link" target="_blank" class="vertical-align-center space-between">
+            <a
+              :href="link"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="vertical-align-center space-between"
+            >
               <span>{{ title }}</span>
               <el-icon :size="20"><Right /></el-icon>
             </a>
@@ -40,7 +45,7 @@
           <div class="card-product-bd">
             <p class="card-product-name text-title">{{ item.title }}</p>
             <p class="card-product-desc tip">{{ item.desc }}</p>
-            <a :href="item.link" target="_blank" class="link-product">
+            <a :href="item.link" target="_blank" rel="noopener noreferrer" class="link-product">
               <span>{{ item.linkText }}</span>
               <el-icon><Right /></el-icon>
             </a>
@@ -60,6 +65,7 @@
             :key="link"
             :href="link"
             target="_blank"
+            rel="noopener noreferrer"
           >
             <i class="iconfont" :class="icon"></i>
           </a>

--- a/src/views/Settings/components/DocListCard.vue
+++ b/src/views/Settings/components/DocListCard.vue
@@ -11,7 +11,7 @@
     <div class="sub-block-docs">
       <ul class="list-link">
         <li class="item-link" v-for="{ link, title } in docList" :key="link">
-          <a :href="link" target="_blank" class="vertical-align-center">
+          <a :href="link" target="_blank" rel="noopener noreferrer" class="vertical-align-center">
             <span>{{ title }}</span>
             <el-icon><Right /></el-icon>
           </a>


### PR DESCRIPTION
- add noopener and noreferrer to external links using target="_blank"
- preserve rel attributes when sanitizing rendered Markdown content

Closes #3877