### PR TITLE
fix(monitoring): omit stale OpenTelemetry exporter protocol

### DIFF
--- a/src/components/TLSConfig/CertBundleInUseDialog.vue
+++ b/src/components/TLSConfig/CertBundleInUseDialog.vue
@@ -76,6 +76,7 @@ const moduleToPath: Record<string, string> = {
   authorization: '/authorization',
   authentication: '/authentication',
   file_transfer: '/file-transfer',
+  opentelemetry: '/monitoring/integration',
 }
 
 // Modules where the second array element represents an object type
@@ -92,6 +93,7 @@ const labelKeyMap: Record<string, string> = {
   authorization: 'refModuleAuthorization',
   authentication: 'refModuleAuthentication',
   file_transfer: 'refModuleFileTransfer',
+  opentelemetry: 'refModuleOpenTelemetry',
 }
 
 const getModuleLabel = (module: string, types: string[]): string => {

--- a/src/components/TextareaWithUploader.vue
+++ b/src/components/TextareaWithUploader.vue
@@ -26,7 +26,7 @@ export default defineComponent({
 </script>
 
 <script setup lang="ts">
-import { UploadFile } from 'element-plus'
+import { formItemContextKey, UploadFile } from 'element-plus'
 
 const props = defineProps({
   modelValue: {
@@ -52,6 +52,7 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['update:modelValue'])
+const formItem = inject(formItemContextKey, undefined)
 
 const { tl } = useI18nTl('Base')
 
@@ -97,6 +98,8 @@ const handleChange = async (file: UploadFile) => {
       await confirmReplacement()
     }
     inputValue.value = content as string
+    await nextTick()
+    formItem?.validate('').catch(() => undefined)
   }
   reader.onerror = () => {
     ElMessage.error(tl('uploadFailed'))

--- a/src/i18n/BasicConfig.ts
+++ b/src/i18n/BasicConfig.ts
@@ -596,6 +596,10 @@ See EMQX documentation for expression syntax.`,
     zh: '文件传输',
     en: 'File Transfer',
   },
+  refModuleOpenTelemetry: {
+    zh: 'OpenTelemetry',
+    en: 'OpenTelemetry',
+  },
   refItemCount: {
     zh: '{count} 个',
     en: '{count}',

--- a/src/views/Config/Monitoring/MonitoringIntegration.vue
+++ b/src/views/Config/Monitoring/MonitoringIntegration.vue
@@ -570,10 +570,12 @@ const createCurrentOpenTelemetryConfig = (): OpenTelemetry => {
   if (config.exporter.auth.ssl) {
     config.exporter.auth.ssl = handleSSLDataBeforeSubmit(config.exporter.auth.ssl)
   }
+  // Protocol is not configurable in the Dashboard and has a different default for each type.
+  // Omit any value loaded for the previous type so the API can apply the correct default.
   if (config.type === 'dynatrace') {
-    return omit(config, 'metrics') as DynatraceOpenTelemetry
+    return omit(config, ['metrics', 'exporter.protocol']) as DynatraceOpenTelemetry
   }
-  return omit(config, 'exporter.auth') as GenericOpenTelemetry
+  return omit(config, ['exporter.auth', 'exporter.protocol']) as GenericOpenTelemetry
 }
 const currentOpenTelemetryConfig = computed(createCurrentOpenTelemetryConfig)
 const dynatraceAuth = computed(() =>


### PR DESCRIPTION
- let the API apply the correct protocol default for each integration type
- prevent generic protocol values from leaking into Dynatrace requests

fixes https://github.com/emqx/emqx-dashboard5/issues/3936
fixes https://github.com/emqx/emqx-dashboard5/issues/3938
fixes https://github.com/emqx/emqx-dashboard5/issues/3941