### PR TITLE
feat(config): add Dashboard listener configuration

### DIFF
--- a/src/common/docLinks.ts
+++ b/src/common/docLinks.ts
@@ -32,6 +32,7 @@ type DocKey =
   | 'tdengineBatchSettings'
   | 'datalayersBatchSettings'
   | 'licenseFaq'
+  | 'acmePlugin'
 
 export type DocMap = Record<DocKey, string>
 
@@ -107,6 +108,7 @@ const createDocLinks = (lang: string): DocMap => {
       lang,
     )}`,
     licenseFaq: `https://www.emqx.com/${lang}/content/license-faq?${createQueryStr({})}`,
+    acmePlugin: `https://docs.emqx.com/${lang}/emqx/latest/extensions/plugin-catalog/6.1/emqx-acme.html#emqx-acme-plugin`,
   }
 }
 

--- a/src/hooks/useMenus.ts
+++ b/src/hooks/useMenus.ts
@@ -52,10 +52,11 @@ const useMenus = (): {
         { title: 'namespace', path: '/namespace' },
         { title: 'rule-engine-security', path: '/rule-engine-security' },
         { title: 'listener', path: '/listener' },
+        { title: 'dashboard-listeners', path: '/dashboard-listeners' },
+        { title: 'certificates', path: '/certificates' },
         { title: 'log', path: '/log' },
         { title: 'monitoring', path: '/monitoring' },
         { title: 'cluster-linking', path: '/cluster-linking' },
-        { title: 'certificates', path: '/certificates' },
       ],
     },
     {

--- a/src/i18n/DashboardListener.ts
+++ b/src/i18n/DashboardListener.ts
@@ -1,0 +1,54 @@
+export default {
+  http: {
+    zh: 'HTTP',
+    en: 'HTTP',
+  },
+  https: {
+    zh: 'HTTPS',
+    en: 'HTTPS',
+  },
+  currentConnection: {
+    zh: '当前连接',
+    en: 'Current Connection',
+  },
+  editTip: {
+    zh: '为避免当前 Dashboard 连接中断，只能修改当前连接未使用的监听器。',
+    en: 'To avoid interrupting the current Dashboard connection, only the listener not used by the current connection can be modified.',
+  },
+  enable: {
+    zh: '启用监听器',
+    en: 'Enable Listener',
+  },
+  bind: {
+    zh: '监听地址',
+    en: 'Bind',
+  },
+  bindPlaceholder: {
+    zh: '例如：18083 或 0.0.0.0:18083',
+    en: 'For example: 18083 or 0.0.0.0:18083',
+  },
+  certificateBundle: {
+    zh: '证书 Bundle',
+    en: 'Certificate Bundle',
+  },
+  certificateBundlePlaceholder: {
+    zh: '请选择证书 Bundle',
+    en: 'Select a certificate bundle',
+  },
+  acmePlugin: {
+    zh: 'ACME 插件文档',
+    en: 'ACME plugin documentation',
+  },
+  acmeTip: {
+    zh: '如需自动申请和续期 HTTPS 证书，请参阅 {link}。',
+    en: 'For automatic HTTPS certificate issuance and renewal, see the {link}.',
+  },
+  atLeastOneListener: {
+    zh: 'HTTP 和 HTTPS 监听器不能同时关闭。',
+    en: 'The HTTP and HTTPS listeners cannot both be disabled.',
+  },
+  fieldRequired: {
+    zh: '启用监听器时必须配置{field}。',
+    en: '{field} is required when the listener is enabled.',
+  },
+}

--- a/src/i18n/components.ts
+++ b/src/i18n/components.ts
@@ -27,6 +27,10 @@ export default {
     zh: '证书',
     en: 'Certificates',
   },
+  'dashboard-listeners': {
+    zh: 'Dashboard 监听器',
+    en: 'Dashboard Listeners',
+  },
   management: {
     zh: '管理',
     en: 'Management',

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -653,6 +653,21 @@ export const routes: Array<RouteRecordRaw> = [
     ],
   },
   {
+    path: '/dashboard-listeners',
+    component: Layout,
+    meta: {
+      hideKey: 'dashboard-listeners',
+      authRequired: true,
+    },
+    children: [
+      {
+        path: '',
+        name: 'dashboard-listeners',
+        component: () => import('@/views/Config/BasicConfig/DashboardListeners.vue'),
+      },
+    ],
+  },
+  {
     path: '/namespace',
     component: Layout,
     meta: {

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -115,13 +115,27 @@ export interface BurstLimit2 {
   window_time: string
 }
 
+export interface DashboardManagedCerts {
+  bundle_name: string
+}
+
+export interface DashboardHttpListener {
+  enable?: boolean
+  bind?: string | number
+}
+
+export interface DashboardHttpsListener extends DashboardHttpListener {
+  ssl_options?: {
+    managed_certs?: DashboardManagedCerts | DashboardManagedCerts[]
+  }
+}
+
 export interface Dashboard {
-  listeners: Listener[] | Listener
-  default_username: string
-  default_password: string
-  sample_interval: string
-  token_expired_time: string
-  cors: boolean
+  listeners?: {
+    http?: DashboardHttpListener
+    https?: DashboardHttpsListener
+  }
+  [key: string]: unknown
 }
 
 export interface RuleEngineSSRF {

--- a/src/views/Config/BasicConfig/DashboardListeners.vue
+++ b/src/views/Config/BasicConfig/DashboardListeners.vue
@@ -1,0 +1,333 @@
+<template>
+  <div class="dashboard-listeners app-wrapper with-padding-top">
+    <el-card class="app-card allow-overflow">
+      <el-skeleton v-if="configLoading" :rows="8" animated />
+      <template v-else>
+        <el-alert class="mb-4" type="info" :closable="false" show-icon>
+          <template #title>{{ tl('editTip') }}</template>
+        </el-alert>
+        <el-alert class="mb-6" type="info" :closable="false" show-icon>
+          <template #title>
+            <i18n-t keypath="DashboardListener.acmeTip" tag="span">
+              <template #link>
+                <a :href="docMap.acmePlugin" target="_blank" rel="noopener noreferrer">
+                  {{ tl('acmePlugin') }}
+                </a>
+              </template>
+            </i18n-t>
+          </template>
+        </el-alert>
+
+        <el-form
+          ref="formRef"
+          class="configuration-form"
+          label-position="top"
+          :model="formData"
+          :rules="rules"
+        >
+          <el-row :gutter="24">
+            <el-col :xs="24" :sm="24" :md="12">
+              <el-card class="listener-card" shadow="never">
+                <template #header>
+                  <div class="listener-card-header">
+                    <span>{{ tl('http') }}</span>
+                    <el-tag v-if="isCurrentProtocol('http')" type="info" effect="plain">
+                      {{ tl('currentConnection') }}
+                    </el-tag>
+                  </div>
+                </template>
+
+                <el-form-item :label="tl('enable')" prop="http.enable">
+                  <el-switch
+                    v-model="formData.http.enable"
+                    :disabled="isCurrentProtocol('http')"
+                    :before-change="() => beforeListenerToggle('http')"
+                  />
+                </el-form-item>
+                <el-form-item :label="tl('bind')" prop="http.bind">
+                  <el-input
+                    v-model.trim="formData.http.bind"
+                    :disabled="isCurrentProtocol('http') || !formData.http.enable"
+                    :placeholder="tl('bindPlaceholder')"
+                  />
+                </el-form-item>
+              </el-card>
+            </el-col>
+
+            <el-col :xs="24" :sm="24" :md="12">
+              <el-card class="listener-card" shadow="never">
+                <template #header>
+                  <div class="listener-card-header">
+                    <span>{{ tl('https') }}</span>
+                    <el-tag v-if="isCurrentProtocol('https')" type="info" effect="plain">
+                      {{ tl('currentConnection') }}
+                    </el-tag>
+                  </div>
+                </template>
+
+                <el-form-item :label="tl('enable')" prop="https.enable">
+                  <el-switch
+                    v-model="formData.https.enable"
+                    :disabled="isCurrentProtocol('https')"
+                    :before-change="() => beforeListenerToggle('https')"
+                  />
+                </el-form-item>
+                <el-form-item :label="tl('bind')" prop="https.bind">
+                  <el-input
+                    v-model.trim="formData.https.bind"
+                    :disabled="isCurrentProtocol('https') || !formData.https.enable"
+                    :placeholder="tl('bindPlaceholder')"
+                  />
+                </el-form-item>
+                <el-form-item :label="tl('certificateBundle')" prop="https.bundleName">
+                  <el-select
+                    v-model="formData.https.bundleName"
+                    filterable
+                    :loading="bundleLoading"
+                    :disabled="isCurrentProtocol('https') || !formData.https.enable"
+                    :placeholder="tl('certificateBundlePlaceholder')"
+                  >
+                    <el-option
+                      v-for="bundle in bundleOptions"
+                      :key="bundle"
+                      :label="bundle"
+                      :value="bundle"
+                    />
+                  </el-select>
+                </el-form-item>
+              </el-card>
+            </el-col>
+          </el-row>
+
+          <div class="form-actions">
+            <el-button
+              type="primary"
+              :loading="saveLoading"
+              :disabled="!hasChanges || !$hasPermission('put')"
+              @click="saveChanges"
+            >
+              {{ t('Base.saveChanges') }}
+            </el-button>
+          </div>
+        </el-form>
+      </template>
+    </el-card>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { getDashboardConfigs, updateDashboardConfigs } from '@/api/config'
+import type { Dashboard, DashboardManagedCerts } from '@/types/config'
+import type { FormInstance, FormItemRule, FormRules } from 'element-plus'
+
+type DashboardProtocol = 'http' | 'https'
+
+interface ListenerForm {
+  enable: boolean
+  bind: string
+}
+
+interface DashboardListenersForm {
+  http: ListenerForm
+  https: ListenerForm & {
+    bundleName: string
+  }
+}
+
+const createDefaultForm = (): DashboardListenersForm => ({
+  http: {
+    enable: true,
+    bind: '18083',
+  },
+  https: {
+    enable: false,
+    bind: '18084',
+    bundleName: '',
+  },
+})
+
+const { t, tl } = useI18nTl('DashboardListener')
+const { docMap } = useDocLink()
+const { getCertBundleList } = useCertBundle()
+
+const currentProtocol: DashboardProtocol = window.location.protocol === 'https:' ? 'https' : 'http'
+const editableProtocol: DashboardProtocol = currentProtocol === 'https' ? 'http' : 'https'
+
+const formRef = ref<FormInstance>()
+const formData = ref<DashboardListenersForm>(createDefaultForm())
+const rawData = ref<DashboardListenersForm>()
+const configLoading = ref(true)
+const bundleLoading = ref(false)
+const saveLoading = ref(false)
+const bundleOptions = ref<string[]>([])
+
+const isCurrentProtocol = (protocol: DashboardProtocol) => protocol === currentProtocol
+const otherProtocol = (protocol: DashboardProtocol): DashboardProtocol =>
+  protocol === 'http' ? 'https' : 'http'
+
+const getManagedCertBundleName = (
+  managedCerts?: DashboardManagedCerts | DashboardManagedCerts[],
+): string => {
+  if (Array.isArray(managedCerts)) {
+    return managedCerts[0]?.bundle_name ?? ''
+  }
+  return managedCerts?.bundle_name ?? ''
+}
+
+const normalizeConfig = (config: Dashboard): DashboardListenersForm => ({
+  http: {
+    enable: config.listeners?.http?.enable ?? false,
+    bind: String(config.listeners?.http?.bind ?? '18083'),
+  },
+  https: {
+    enable: config.listeners?.https?.enable ?? false,
+    bind: String(config.listeners?.https?.bind ?? '18084'),
+    bundleName: getManagedCertBundleName(config.listeners?.https?.ssl_options?.managed_certs),
+  },
+})
+
+const normalizeBindForPayload = (bind: string): string | number => {
+  const value = bind.trim()
+  return /^\d+$/.test(value) ? Number(value) : value
+}
+
+const hasChanges = computed(() => (rawData.value ? !isEqual(formData.value, rawData.value) : false))
+useDataNotSaveConfirm(() => hasChanges.value)
+
+const createListenerFieldRule = (protocol: DashboardProtocol, label: string): FormItemRule => ({
+  validator: (_rule, value: string, callback) => {
+    if (protocol !== editableProtocol) {
+      callback()
+      return
+    }
+    if (formData.value[protocol].enable && !value?.trim()) {
+      callback(new Error(tl('fieldRequired', { field: label })))
+      return
+    }
+    callback()
+  },
+  trigger: ['blur', 'change'],
+})
+
+const rules: FormRules = {
+  'http.bind': [createListenerFieldRule('http', tl('bind'))],
+  'https.bind': [createListenerFieldRule('https', tl('bind'))],
+  'https.bundleName': [createListenerFieldRule('https', tl('certificateBundle'))],
+}
+
+const beforeListenerToggle = (protocol: DashboardProtocol) => {
+  const listener = formData.value[protocol]
+  const peerListener = formData.value[otherProtocol(protocol)]
+  if (listener.enable && !peerListener.enable) {
+    ElMessage.warning(tl('atLeastOneListener'))
+    return false
+  }
+  return true
+}
+
+const loadBundleOptions = async () => {
+  try {
+    bundleLoading.value = true
+    const bundles = await getCertBundleList()
+    bundleOptions.value = bundles.flatMap(({ name }) => (name ? [name] : []))
+  } catch (error) {
+    // The HTTP listener can still be configured if certificate loading fails.
+  } finally {
+    bundleLoading.value = false
+  }
+}
+
+const loadConfig = async () => {
+  try {
+    configLoading.value = true
+    const config = await getDashboardConfigs()
+    formData.value = normalizeConfig(config)
+    rawData.value = cloneDeep(formData.value)
+  } catch (error) {
+    // HTTP errors are handled globally.
+  } finally {
+    configLoading.value = false
+  }
+}
+
+const createPayload = (): Dashboard => {
+  const listener = formData.value[editableProtocol]
+  if (!listener.enable) {
+    return {
+      listeners: {
+        [editableProtocol]: { enable: false },
+      },
+    }
+  }
+
+  if (editableProtocol === 'http') {
+    return {
+      listeners: {
+        http: {
+          enable: true,
+          bind: normalizeBindForPayload(listener.bind),
+        },
+      },
+    }
+  }
+
+  return {
+    listeners: {
+      https: {
+        enable: true,
+        bind: normalizeBindForPayload(listener.bind),
+        ssl_options: {
+          managed_certs: {
+            bundle_name: formData.value.https.bundleName,
+          },
+        },
+      },
+    },
+  }
+}
+
+const saveChanges = async () => {
+  if (!formData.value.http.enable && !formData.value.https.enable) {
+    ElMessage.warning(tl('atLeastOneListener'))
+    return
+  }
+
+  try {
+    await formRef.value?.validate()
+    saveLoading.value = true
+    await updateDashboardConfigs(createPayload())
+    ElMessage.success(t('Base.updateSuccess'))
+    await loadConfig()
+  } catch (error) {
+    // HTTP and validation errors are handled globally or by the form.
+  } finally {
+    saveLoading.value = false
+  }
+}
+
+loadConfig()
+loadBundleOptions()
+</script>
+
+<style lang="scss">
+.dashboard-listeners {
+  .listener-card {
+    height: 100%;
+  }
+
+  .listener-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-weight: 600;
+  }
+
+  .el-select {
+    width: 100%;
+  }
+
+  .form-actions {
+    margin-top: 24px;
+  }
+}
+</style>


### PR DESCRIPTION
- add a dedicated page for managing HTTP and HTTPS listeners
- restrict editing to the listener not used by the current connection
- prevent both listeners from being disabled
- support managed certificate bundles and link to the ACME documentation