### PR TITLE
fix(authn): exclude OAuth2 from HTTP SCRAM config

### DIFF
--- a/src/hooks/Auth/useAuthnCreate.ts
+++ b/src/hooks/Auth/useAuthnCreate.ts
@@ -47,9 +47,13 @@ export default function useAuthnCreate() {
       max_inactive: '10s',
       enable_pipelining: 100,
       ssl: createSSLForm(),
-      oauth2: {
-        enable: false,
-      },
+      ...(type === 'password_based'
+        ? {
+            oauth2: {
+              enable: false,
+            },
+          }
+        : {}),
       ...(type === 'scram'
         ? {
             algorithm: 'sha256',
@@ -213,6 +217,9 @@ export default function useAuthnCreate() {
       switch (backend) {
         case 'http':
           data = processHttpConfig(config)
+          if (mechanism === 'scram') {
+            delete data.oauth2
+          }
           break
         case 'redis':
           data = processRedisConfig(config)

--- a/src/views/Auth/components/HttpConfig.vue
+++ b/src/views/Auth/components/HttpConfig.vue
@@ -36,7 +36,7 @@
               <key-and-value-editor v-model="httpConfig.headers" />
             </el-form-item>
           </el-col>
-          <HttpOAuth2Config v-model="httpConfig.oauth2" :is-edit="isEdit" />
+          <HttpOAuth2Config v-if="supportsOAuth2" v-model="httpConfig.oauth2" :is-edit="isEdit" />
           <el-col :span="12" v-if="type === 'scram'">
             <el-form-item :label="tl('passwordHash')">
               <el-select v-model="httpConfig.algorithm" clearable>
@@ -171,7 +171,8 @@ export default defineComponent({
     }
     const defaultContent = JSON.stringify(httpJSON, null, 2)
     const httpConfig = ref(props.modelValue)
-    if (!httpConfig.value.oauth2) {
+    const supportsOAuth2 = computed(() => props.authType !== 'authn' || props.type !== 'scram')
+    if (supportsOAuth2.value && !httpConfig.value.oauth2) {
       httpConfig.value.oauth2 = { enable: false }
     }
     const { formCom, rules, validate } = useHTTPConfigForm()
@@ -193,6 +194,9 @@ export default defineComponent({
 
     const isMethodGet = computed(() => httpConfig.value.method === 'get')
     const { factory } = useAuthnCreate()
+    /**
+     * just for get headers
+     */
     const { headers: defaultHeaders } = factory('password_based', 'http')
     const handleMethodChanged = () => {
       if (isMethodGet.value && isEqual(httpConfig.value.headers, defaultHeaders)) {
@@ -234,6 +238,7 @@ export default defineComponent({
       formCom,
       rules,
       isMethodGet,
+      supportsOAuth2,
       handleMethodChanged,
       validate,
       toggleNeedHelp,


### PR DESCRIPTION
- hide OAuth2 settings for HTTP SCRAM authentication
- omit OAuth2 from the default SCRAM configuration
- remove stale OAuth2 data before submitting SCRAM requests

Fixes #3955