### PR TITLE
fix(plugin): mask saved passwords in configuration forms

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -154,6 +154,7 @@ declare global {
   const createFunctionItem: typeof import('./hooks/Flow/useNodeForm')['createFunctionItem']
   const createMessageForm: typeof import('./hooks/Flow/useNodeForm')['createMessageForm']
   const createOrderObj: typeof import('./common/tools')['createOrderObj']
+  const createPluginPasswordForm: typeof import('./hooks/Plugins/pluginPasswordForm')['createPluginPasswordForm']
   const createRandomString: typeof import('./common/tools')['createRandomString']
   const createRePubForm: typeof import('./hooks/Flow/useNodeForm')['createRePubForm']
   const createRouter: typeof import('vue-router')['createRouter']
@@ -730,6 +731,7 @@ declare module 'vue' {
     readonly createFunctionItem: UnwrapRef<typeof import('./hooks/Flow/useNodeForm')['createFunctionItem']>
     readonly createMessageForm: UnwrapRef<typeof import('./hooks/Flow/useNodeForm')['createMessageForm']>
     readonly createOrderObj: UnwrapRef<typeof import('./common/tools')['createOrderObj']>
+    readonly createPluginPasswordForm: UnwrapRef<typeof import('./hooks/Plugins/pluginPasswordForm')['createPluginPasswordForm']>
     readonly createRandomString: UnwrapRef<typeof import('./common/tools')['createRandomString']>
     readonly createRePubForm: UnwrapRef<typeof import('./hooks/Flow/useNodeForm')['createRePubForm']>
     readonly createRouter: UnwrapRef<typeof import('vue-router')['createRouter']>

--- a/src/components/PluginsForm/PluginFormKit.vue
+++ b/src/components/PluginsForm/PluginFormKit.vue
@@ -3,7 +3,8 @@
     ref="PluginForm"
     class="plugin-form-kit"
     :rules="rules"
-    :model="configsForm"
+    :model="validationModel"
+    :disabled="saveLoading"
     scroll-to-error
     :scroll-into-view-options="{ behavior: 'smooth' }"
     label-position="top"
@@ -15,6 +16,7 @@
         :key="name"
         :name="name as string"
         :form-configs="configs"
+        @password-edited="editedPasswords.add($event)"
       />
     </el-row>
     <el-row>
@@ -35,6 +37,7 @@
 <script lang="ts" setup>
 import { PluginUIConfigs } from '@/types/plugin'
 import PluginFormKitItem from './PluginFormKitItem.vue'
+import { createPluginPasswordForm } from '@/hooks/Plugins/pluginPasswordForm'
 
 const props = defineProps({
   data: {
@@ -56,7 +59,19 @@ const emit = defineEmits(['saved'])
 
 const PluginForm = ref()
 
-const configsForm = ref(cloneDeep(props.data))
+const passwordForm = shallowRef(createPluginPasswordForm(props.data, props.layouts.$form))
+const configsForm = ref(passwordForm.value.values)
+const editedPasswords = ref(new Set<string>())
+// Validate the actual values, so a six-character mask cannot fail password rules.
+const validationModel = computed(() =>
+  passwordForm.value.restore(configsForm.value, editedPasswords.value),
+)
+
+const resetForm = (data: Record<string, any>) => {
+  passwordForm.value = createPluginPasswordForm(data, props.layouts.$form)
+  configsForm.value = passwordForm.value.values
+  editedPasswords.value = new Set()
+}
 
 const saveLoading = ref(false)
 
@@ -67,12 +82,8 @@ const { rules } = useGenPluginFormRules({
 })
 
 watch(
-  () => props.data,
-  (val) => {
-    nextTick(() => {
-      configsForm.value = cloneDeep(val)
-    })
-  },
+  () => [props.data, props.layouts],
+  () => resetForm(props.data),
   { deep: true },
 )
 
@@ -83,7 +94,9 @@ async function save() {
     if (!valid) {
       return
     }
-    await props.saveFunc(configsForm.value)
+    const data = passwordForm.value.restore(configsForm.value, editedPasswords.value)
+    await props.saveFunc(data)
+    resetForm(data)
     ElMessage.success(t('Base.updateSuccess'))
     emit('saved', configsForm.value)
   } catch (error) {

--- a/src/components/PluginsForm/PluginFormKitItem.vue
+++ b/src/components/PluginsForm/PluginFormKitItem.vue
@@ -15,13 +15,11 @@
           type="number"
           v-model="bindValue"
         ></custom-input-number>
-        <el-input
+        <CustomInputPassword
           v-else-if="formConfigs.component === 'input-password'"
-          type="password"
           v-model="bindValue"
-          show-password
-          autocomplete="one-time-code"
-        ></el-input>
+          @input="emit('password-edited', name)"
+        ></CustomInputPassword>
         <el-input
           v-else-if="formConfigs.component === 'input-textarea'"
           type="textarea"
@@ -66,6 +64,7 @@
       :name="`${name}.${key}`"
       :form-configs="value"
       v-model="bindValue[key]"
+      @password-edited="emit('password-edited', $event)"
     />
   </template>
   <el-col v-if="formConfigs.divider" :span="24">
@@ -83,6 +82,7 @@ export default {
 import { ConfigField } from '@/types/plugin'
 import PluginFormKitItem from './PluginFormKitItem.vue'
 import CustomInputNumber from '../CustomInputNumber.vue'
+import CustomInputPassword from '@/components/CustomInputPassword.vue'
 
 const props = defineProps({
   modelValue: [String, Number, Array, Object, Boolean] as PropType<any>,
@@ -96,7 +96,7 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['update:modelValue'])
+const emit = defineEmits(['update:modelValue', 'password-edited'])
 
 const bindValue = ref(props.modelValue)
 

--- a/src/hooks/Plugins/pluginPasswordForm.ts
+++ b/src/hooks/Plugins/pluginPasswordForm.ts
@@ -1,0 +1,43 @@
+import { cloneDeep, get, set } from 'lodash'
+import type { ConfigField } from '@/types/plugin'
+
+const PASSWORD_MASK = '******'
+
+/** Keep saved passwords separate from the editable form, including nested records. */
+export function createPluginPasswordForm(
+  data: Record<string, any>,
+  fields: Record<string, ConfigField>,
+) {
+  const original = cloneDeep(data)
+  const values = cloneDeep(data)
+  const passwordPaths: string[][] = []
+
+  const maskFields = (configs: Record<string, ConfigField>, parent: string[] = []) => {
+    Object.entries(configs).forEach(([name, config]) => {
+      const path = [...parent, name]
+      if (config.component === 'input-password') {
+        passwordPaths.push(path)
+        const value = get(original, path)
+        if (typeof value === 'string' && value !== '') {
+          set(values, path, PASSWORD_MASK)
+        }
+      } else if (!config.component && config.children) {
+        maskFields(config.children, path)
+      }
+    })
+  }
+  maskFields(fields)
+
+  return {
+    values,
+    restore(form: Record<string, any>, editedFields: ReadonlySet<string>) {
+      const result = cloneDeep(form)
+      passwordPaths.forEach((path) => {
+        if (!editedFields.has(path.join('.')) && get(result, path) === PASSWORD_MASK) {
+          set(result, path, get(original, path))
+        }
+      })
+      return result
+    },
+  }
+}

--- a/src/i18n/General.ts
+++ b/src/i18n/General.ts
@@ -1,4 +1,12 @@
 export default {
+  requestBindings: {
+    zh: '路径参数',
+    en: 'Path Parameters',
+  },
+  requestBody: {
+    zh: '请求体',
+    en: 'Request Body',
+  },
   expireAt: {
     zh: '到期时间',
     en: 'Expire At',

--- a/src/types/schemas/audit.schemas.ts
+++ b/src/types/schemas/audit.schemas.ts
@@ -85,7 +85,7 @@ export const AuditHttpRequestMethod = {
 
 export type AuditHttpRequestHeaders = { [key: string]: unknown }
 
-export type AuditHttpRequestBody = { [key: string]: unknown }
+export type AuditHttpRequestBody = { [key: string]: unknown } | string
 
 export type AuditHttpRequestBindings = { [key: string]: unknown }
 

--- a/src/views/General/AuditLog.vue
+++ b/src/views/General/AuditLog.vue
@@ -124,21 +124,6 @@
               <template v-else>
                 {{ Array.isArray(row.args) ? row.args.join(' ') : row.args }}
               </template>
-              <template
-                v-if="
-                  row.http_request.bindings && Object.keys(row.http_request.bindings).length > 0
-                "
-              >
-                <InfoTooltip popper-class="code-popper">
-                  <template #content>
-                    <CodeView
-                      lang="json"
-                      :code="stringifyObjSafely(row.http_request.bindings)"
-                      :show-copy-btn="false"
-                    />
-                  </template>
-                </InfoTooltip>
-              </template>
             </template>
           </el-table-column>
           <el-table-column :label="tl('opSource')">
@@ -158,12 +143,43 @@
               {{ getLabelFromOpts(row.operation_result, requestResultOpt) || '--' }}
             </template>
           </el-table-column>
+          <el-table-column :label="t('Base.operation')" width="120">
+            <template #default="{ row }">
+              <el-button
+                v-if="getRequestDetails(row).length"
+                size="small"
+                @click="openRequestDetails(row)"
+              >
+                {{ t('Base.detail') }}
+              </el-button>
+              <span v-else>--</span>
+            </template>
+          </el-table-column>
         </el-table>
         <div class="emq-table-footer">
           <common-pagination v-model:metaData="pageMeta" @loadPage="getData"></common-pagination>
         </div>
       </div>
     </template>
+    <el-dialog
+      v-model="showRequestDetails"
+      :title="t('Base.detail')"
+      width="500px"
+      class="audit-request-dialog"
+    >
+      <div class="request-details">
+        <div v-for="detail in requestDetails" :key="detail.label" class="request-detail">
+          <h3>{{ detail.label }}</h3>
+          <CodeView
+            lang="json"
+            :code="
+              typeof detail.value === 'string' ? detail.value : stringifyObjSafely(detail.value, 2)
+            "
+            :show-copy-btn="true"
+          />
+        </div>
+      </div>
+    </el-dialog>
   </div>
 </template>
 
@@ -257,6 +273,27 @@ const notSupportHTTPFilter = computed(() => {
 const isInitializing = ref(false)
 const isTableLoading = ref(false)
 const tableData: Ref<Array<AuditLogItem>> = ref([])
+const getRequestDetails = ({ http_request }: AuditLogItem) => {
+  return [
+    { label: tl('requestBindings'), value: http_request?.bindings },
+    { label: tl('requestBody'), value: http_request?.body },
+  ].filter(
+    (detail): detail is { label: string; value: Record<string, unknown> | string } =>
+      detail.value != null &&
+      (typeof detail.value === 'string'
+        ? detail.value.length > 0
+        : Object.keys(detail.value).length > 0),
+  )
+}
+const showRequestDetails = ref(false)
+const selectedLog = ref<AuditLogItem>()
+const requestDetails = computed(() =>
+  selectedLog.value ? getRequestDetails(selectedLog.value) : [],
+)
+const openRequestDetails = (row: AuditLogItem) => {
+  selectedLog.value = row
+  showRequestDetails.value = true
+}
 const { pageMeta, pageParams, setPageMeta } = usePaginationWithHasNext()
 
 const confirmAuditLogEnabled = async () => {
@@ -426,14 +463,25 @@ init()
     opacity: 0.8;
   }
 }
-.code-popper.el-popper {
-  padding: 0;
+.audit-request-dialog {
+  max-width: 90vw;
+  .request-details {
+    max-height: 60vh;
+    overflow: auto;
+  }
+  .request-detail + .request-detail {
+    margin-top: 24px;
+  }
+  h3 {
+    margin: 0 0 12px;
+    font-size: 14px;
+  }
   .code-view {
     margin: 0;
-  }
-  .hljs {
-    padding: 12px;
-    border: none;
+    pre code {
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+    }
   }
 }
 </style>


### PR DESCRIPTION
- Display saved passwords as six asterisks, including nested fields
- Restore unedited passwords for validation and submission
- Track password edits to support replacements, clearing, and literal masks
- Use CustomInputPassword and reapply masking after successful saves

Fixes #3971