### PR TITLE
fix(audit): restrict audit log access to global users

### DIFF
--- a/src/auto-imports.d.ts
+++ b/src/auto-imports.d.ts
@@ -420,6 +420,7 @@ declare global {
   const useModel: typeof import('vue')['useModel']
   const useMove: typeof import('./hooks/useMove')['default']
   const useNamespace: typeof import('./hooks/Config/useNamespace')['default']
+  const useNamespaceAccess: typeof import('./hooks/useNamespaceAccess')['default']
   const useNamespaceUser: typeof import('./hooks/Config/useNamespaceUser')['default']
   const useNamespaceUserRouter: typeof import('./hooks/useNamespaceUserRouter')['default']
   const useNodeDrawer: typeof import('./hooks/Flow/useNodeDrawer')['default']
@@ -1001,6 +1002,7 @@ declare module 'vue' {
     readonly useModel: UnwrapRef<typeof import('vue')['useModel']>
     readonly useMove: UnwrapRef<typeof import('./hooks/useMove')['default']>
     readonly useNamespace: UnwrapRef<typeof import('./hooks/Config/useNamespace')['default']>
+    readonly useNamespaceAccess: UnwrapRef<typeof import('./hooks/useNamespaceAccess')['default']>
     readonly useNamespaceUser: UnwrapRef<typeof import('./hooks/Config/useNamespaceUser')['default']>
     readonly useNamespaceUserRouter: UnwrapRef<typeof import('./hooks/useNamespaceUserRouter')['default']>
     readonly useNodeDrawer: UnwrapRef<typeof import('./hooks/Flow/useNodeDrawer')['default']>

--- a/src/hooks/useMenus.ts
+++ b/src/hooks/useMenus.ts
@@ -1,3 +1,5 @@
+import useNamespaceAccess from './useNamespaceAccess'
+
 export interface Menu {
   title: string
   path?: string
@@ -8,6 +10,7 @@ export interface Menu {
 export default (): {
   menuList: Ref<Array<Menu>>
 } => {
+  const { filterAccessibleItems } = useNamespaceAccess()
   const monitoring = [
     { title: 'dashboard', path: '/dashboard' },
     { title: 'clients', path: '/clients' },
@@ -132,12 +135,7 @@ export default (): {
     },
   ]
 
-  const menuList = computed(() => {
-    // if (isNamespaceUser.value) {
-    //   return totalMenuList.filter((menu) => menu.title === 'ruleengine')
-    // }
-    return totalMenuList
-  })
+  const menuList = computed(() => filterAccessibleItems(totalMenuList))
 
   return {
     menuList,

--- a/src/hooks/useNamespaceAccess.ts
+++ b/src/hooks/useNamespaceAccess.ts
@@ -1,0 +1,32 @@
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+// Add route names here to restrict more pages for namespaced users.
+const globalOnlyRouteNames = new Set(['audit-log'])
+
+interface NavigationItem {
+  path?: string
+  children?: NavigationItem[]
+}
+
+export default function useNamespaceAccess() {
+  const store = useStore()
+  const router = useRouter()
+  const route = useRoute()
+
+  const canAccessPath = (path: string) =>
+    !store.getters.isNamespaceUser ||
+    !router.resolve(path).matched.some(({ name }) => globalOnlyRouteNames.has(String(name)))
+
+  const canAccessCurrentRoute = computed(() => canAccessPath(route.fullPath))
+
+  const filterAccessibleItems = <T extends NavigationItem>(items: T[]): T[] =>
+    items.flatMap((item) => {
+      if (item.path && !canAccessPath(item.path)) return []
+      if (!item.children) return [item]
+      const children = filterAccessibleItems(item.children)
+      return children.length ? [{ ...item, children }] : []
+    })
+
+  return { canAccessCurrentRoute, filterAccessibleItems }
+}

--- a/src/i18n/General.ts
+++ b/src/i18n/General.ts
@@ -477,6 +477,10 @@ Available scopes are still restricted by the user's role. The default scopes for
     zh: '操作方式',
     en: 'Source Type',
   },
+  auditLogGlobalUsersOnly: {
+    zh: '审计日志仅允许全局管理员和全局查看者访问。',
+    en: 'Audit logs are only available to global administrators and global viewers.',
+  },
   auditLogDesc: {
     zh: '审计日志功能可以记录对 EMQX 集群的关键操作，以满足企业在合规性和数据安全方面的需求。',
     en: 'The audit log feature records critical operations on the EMQX cluster to meet enterprise requirements for compliance and data security.',

--- a/src/views/Base/LeftBar.vue
+++ b/src/views/Base/LeftBar.vue
@@ -64,7 +64,6 @@
 export default defineComponent({
   name: 'Leftbar',
   setup() {
-    const menus = ref<Menu[]>([])
     const store = useStore()
     const route = useRoute()
     const leftBarCollapse = computed(() => {
@@ -92,9 +91,7 @@ export default defineComponent({
       return totalH > 740
     }
 
-    const { menuList } = useMenus()
-
-    menus.value = menuList.value
+    const { menuList: menus } = useMenus()
     return {
       store,
       theme,

--- a/src/views/Base/QuickPanel.vue
+++ b/src/views/Base/QuickPanel.vue
@@ -35,6 +35,7 @@
 
 <script lang="ts" setup>
 import { routes } from '@/router'
+import useNamespaceAccess from '@/hooks/useNamespaceAccess'
 import { ArrowRight, Search } from '@element-plus/icons-vue'
 
 interface MenuItem {
@@ -76,6 +77,7 @@ const { t, tl } = useI18nTl('Base')
 const createChildReg = (path: string) => new RegExp(`${path}(/(\\w|-)+)+$`)
 
 const { menuList } = useMenus()
+const { filterAccessibleItems } = useNamespaceAccess()
 const findParentAndBlock = (path: string) => {
   let parent: Menu | any = undefined
   const walk = (menuItem: Menu): boolean => {
@@ -131,17 +133,17 @@ const generateMenuItems = (totalRoutes: Array<RouteRecordRaw>): Array<MenuItem> 
 /**
  * remove page with params
  */
-const neededMenuList = generateMenuItems(routes)
+const neededMenuList = computed(() => filterAccessibleItems(generateMenuItems(routes)))
 
 const input = ref('')
 
 const defaultItemNames = ['overview', 'clients', 'authentication', 'rule']
 const querySearch = (query: string, cb: any) => {
   if (!query) {
-    cb(neededMenuList.filter(({ name }) => defaultItemNames.includes(name)))
+    cb(neededMenuList.value.filter(({ name }) => defaultItemNames.includes(name)))
   } else {
     const queryRegArr = query.split(' ').map((item) => new RegExp(`${escapeRegExp(item)}`, 'i'))
-    const ret = neededMenuList.filter(
+    const ret = neededMenuList.value.filter(
       ({ path, name, label }) =>
         queryRegArr.every((reg) => reg.test(path)) ||
         queryRegArr.every((reg) => reg.test(label)) ||

--- a/src/views/General/AuditLog.vue
+++ b/src/views/General/AuditLog.vue
@@ -1,5 +1,16 @@
 <template>
-  <div class="audit-log" :class="{ 'is-loading': isInitializing }" v-loading.lock="isInitializing">
+  <el-result
+    v-if="!canAccessCurrentRoute"
+    icon="warning"
+    title="403"
+    :sub-title="tl('auditLogGlobalUsersOnly')"
+  />
+  <div
+    v-else
+    class="audit-log"
+    :class="{ 'is-loading': isInitializing }"
+    v-loading.lock="isInitializing"
+  >
     <div v-if="!isInitializing && !isAuditEnabled" class="no-log-tip">
       <img src="@/assets/img/log_disabled.png" alt="" width="376" />
       <p>{{ tl('auditLogDesc') }}</p>
@@ -183,6 +194,7 @@
 <script lang="ts" setup>
 import { getLogConfigs, updateLogConfigs } from '@/api/config'
 import { queryAuditLogs } from '@/api/systemModule'
+import useNamespaceAccess from '@/hooks/useNamespaceAccess'
 import { GLOBAL_NAMESPACE, SEARCH_FORM_RES_PROPS as colProps } from '@/common/constants'
 import {
   getLabelFromValueInOptionList as getLabelFromOpts,
@@ -223,7 +235,9 @@ const METHOD_PATH_CONNECTOR = ':'
 const CHILDREN_PATH_FOR_MAT = '[...]'
 
 const { t, tl } = useI18nTl('General')
-const { state } = useStore()
+const store = useStore()
+const { state } = store
+const { canAccessCurrentRoute } = useNamespaceAccess()
 
 const isAuditEnabled = ref(false)
 const isEnabling = ref(false)
@@ -300,8 +314,10 @@ const tableData: Ref<Array<AuditLogItem>> = ref([])
 const { pageMeta, pageParams, setPageMeta } = usePaginationWithHasNext()
 
 const confirmAuditLogEnabled = async () => {
+  const token = state.user.token
   try {
     const { audit } = await getLogConfigs()
+    if (token !== state.user.token || !canAccessCurrentRoute.value) return
     isAuditEnabled.value = !!audit?.enable
   } catch (error) {
     //
@@ -336,19 +352,23 @@ const checkParams = (params: GetAuditParams): Promise<boolean> => {
   return Promise.resolve(true)
 }
 const getData = async () => {
+  if (!canAccessCurrentRoute.value || !state.user.token) return
+  const token = state.user.token
   const filters = pickBy(filterParams, Boolean)
   const params = handleParams({ ...pageParams.value, ...filters })
   try {
     await checkParams(params)
+    if (token !== state.user.token || !canAccessCurrentRoute.value) return
     // if is initializing, do not set isTableLoading
     isTableLoading.value = !isInitializing.value
     const { data, meta } = await queryAuditLogs(params)
+    if (token !== state.user.token || !canAccessCurrentRoute.value) return
     tableData.value = data
     setPageMeta(meta)
   } catch (error) {
     //
   } finally {
-    isTableLoading.value = false
+    if (token === state.user.token) isTableLoading.value = false
   }
 }
 
@@ -364,16 +384,19 @@ const resetFilter = async () => {
 }
 
 const init = async () => {
+  if (!canAccessCurrentRoute.value || !state.user.token) return
+  const token = state.user.token
   try {
     isInitializing.value = true
     await confirmAuditLogEnabled()
+    if (token !== state.user.token || !canAccessCurrentRoute.value) return
     if (isAuditEnabled.value) {
       await getData()
     }
   } catch (error) {
     //
   } finally {
-    isInitializing.value = false
+    if (token === state.user.token) isInitializing.value = false
   }
 }
 const formatDate = (ipt: string) => dayjs(ipt).format('YYYY-MM-DD HH:mm:ss')
@@ -410,6 +433,7 @@ const getLogInfo = ({ operation_id, http_method, operation_type }: AuditLogItem)
 }
 
 const enableModule = async () => {
+  if (!canAccessCurrentRoute.value || !state.user.token) return
   try {
     isEnabling.value = true
     await updateLogConfigs({ audit: { enable: true } } as any)
@@ -421,7 +445,17 @@ const enableModule = async () => {
   }
 }
 
-init()
+watch(
+  () => [state.user.token, canAccessCurrentRoute.value],
+  () => {
+    tableData.value = []
+    isAuditEnabled.value = false
+    isInitializing.value = false
+    isTableLoading.value = false
+    init()
+  },
+  { immediate: true },
+)
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
- Centralize namespace access rules for menus, quick navigation, and pages
- Hide audit log entries and show a permission-denied state for namespaced users
- Skip unauthorized requests and discard stale responses after account changes
- Keep menu visibility reactive when switching accounts

Fixes #3984